### PR TITLE
Utilisation d'Heap Analytics

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,9 +2,9 @@
 # NB: No trailing slash
 NEXT_PUBLIC_API_BASE=https://rnb-api.beta.gouv/fr/api/alpha
 
-# NEXT_PUBLIC_HOTJAR_ID
-# The site id in Hotjar
-NEXT_PUBLIC_HOTJAR_ID=123456
+# NEXT_PUBLIC_HEAP_ID
+# The site/env id in Heap Analytics
+NEXT_PUBLIC_HEAP_ID=123456
 
 # NEXTAUTH_URL
 # https://next-auth.js.org/configuration/options#nextauth_url

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,7 @@ export default async function RootLayout({
       <head>
         <StartDsfr />
         <DsfrHead defaultColorScheme={defaultColorScheme} />
-        <Script id="hotjar">
+        <Script id="heap">
           {`
 window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
 heap.load("${settings.heapId}");

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,14 +43,8 @@ export default async function RootLayout({
         <DsfrHead defaultColorScheme={defaultColorScheme} />
         <Script id="hotjar">
           {`
-(function(h,o,t,j,a,r){
-  h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-  h._hjSettings={hjid:${settings.hotjarId},hjsv:${settings.hotjarVersion}};
-  a=o.getElementsByTagName('head')[0];
-  r=o.createElement('script');r.async=1;
-  r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-  a.appendChild(r);
-})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
+heap.load("${settings.heapId}");
           `}
         </Script>
       </head>

--- a/logic/settings.tsx
+++ b/logic/settings.tsx
@@ -1,7 +1,5 @@
 export default {
     adsFormUrl: "https://framaforms.org/demande-didentifiants-pour-avoir-acces-aux-ads-1684847508",
     contactEmail: "rnb@beta.gouv.fr",
-    hotjarId: process.env.NEXT_PUBLIC_HOTJAR_ID,
-    hotjarVersion: "6",
     heapId: process.env.NEXT_PUBLIC_HEAP_ID
 }

--- a/logic/settings.tsx
+++ b/logic/settings.tsx
@@ -3,4 +3,5 @@ export default {
     contactEmail: "rnb@beta.gouv.fr",
     hotjarId: process.env.NEXT_PUBLIC_HOTJAR_ID,
     hotjarVersion: "6",
+    heapId: process.env.NEXT_PUBLIC_HEAP_ID
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@codegouvfr/react-dsfr": "^0.51.0",
-    "@hotjar/browser": "^1.0.9",
     "@reduxjs/toolkit": "^1.9.5",
     "@types/node": "18.15.11",
     "@types/react": "18.0.35",


### PR DESCRIPTION
Gitbook a complètement fait disparaitre les statistiques de visite de ses fonctionnalités.
Hotjar ne donne pas satisfaction pour consulter de simples statistiques de visites et autre indicateurs sur le site public.
Vercel Analytics permet de suivre quelques indicateurs et évènements custom mais est trop limité.

Nous commençons à changer notre solution d'analytics pour tout faire vivre dans Heap. Cette PR contient le changement d'Hotjar à Heap pour le site public.