### PR TITLE
Mise à jour de l'URL lorsqu'on clique sur un batiment

### DIFF
--- a/components/VisuMap.tsx
+++ b/components/VisuMap.tsx
@@ -20,6 +20,7 @@ import React, { useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from "react-redux";
 import { fetchBdg, openPanel } from "@/stores/map/slice";
 
+
 export default function VisuMap() {
 
 
@@ -110,7 +111,8 @@ export default function VisuMap() {
         highlightBdg(rnb_id)
 
         // update the url query with the rnb_id
-        window.history.pushState({}, '', `?q=${rnb_id}`)
+        window.history.replaceState({}, '', `?q=${rnb_id}`)
+        
 
         // Dispatch to store
         await dispatch(fetchBdg(rnb_id))

--- a/components/VisuMap.tsx
+++ b/components/VisuMap.tsx
@@ -109,6 +109,9 @@ export default function VisuMap() {
         // Highlight it on the map
         highlightBdg(rnb_id)
 
+        // update the url query with the rnb_id
+        window.history.pushState({}, '', `?q=${rnb_id}`)
+
         // Dispatch to store
         await dispatch(fetchBdg(rnb_id))
         dispatch(openPanel())


### PR DESCRIPTION
Ça sera pratique pour que les gens partagent des urls, dès qu'on clique sur un bâtiment sur la carte, l'URL se met à jour avec `?q=rnb_id`