### PR TITLE
rnb id plus sobre

### DIFF
--- a/components/VisuPanel.tsx
+++ b/components/VisuPanel.tsx
@@ -98,11 +98,6 @@ export default function VisuPanel() {
             if (i == 4 || i == 8) {
                 classes = styles["small-left-padding"]
             }
-            if (i < 4) {
-                classes += ` ${styles["text-light-blue"]}`
-            } else if (i > 7) {
-                classes += ` ${styles["text-red"]}`
-            }
             return <span key={"rnb-id-char" + i} className={classes}>{char}</span >
         })
     }

--- a/styles/mapPanel.module.scss
+++ b/styles/mapPanel.module.scss
@@ -107,14 +107,6 @@
     margin-bottom: 0;
 }
 
-.text-light-blue {
-    color: var(--blue-france-main-525);
-}
-
-.text-red {
-    color: var(--red-marianne-425-625-hover);
-}
-
 .small-left-padding {
-    padding-left: 2px;
+    padding-left: 4px;
 }


### PR DESCRIPTION
Retour à une version plus sobre, suite à la discussion du weekly, pour voir si on préfère

![Capture d’écran 2024-04-15 à 14 35 37](https://github.com/fab-geocommuns/RNB-site/assets/15341118/d8258155-8015-476b-b7ed-818098ca6a9a)
