### PR TITLE
Montrer les points à des niveaux de zoom plus élevés

### DIFF
--- a/components/VisuMap.tsx
+++ b/components/VisuMap.tsx
@@ -170,7 +170,7 @@ export default function VisuMap() {
         tiles: [
           tilesUrl
         ],
-        minzoom: 14,
+        minzoom: 16,
         maxzoom: 22,
         promoteId: 'rnb_id'
       })


### PR DESCRIPTION
remonté par @rmaziere , un utilisateur unique qui se promène sur notre carte assez dézoomé provoque un pic d'utilisation des ressources CPU de notre DB. Alors que la vue n'apporte pas grand chose à priori.

On n'affiche les points que pour 2 niveaux de zoom plus haut  qu'avant.

Exemple de niveau le plus dézoomé qui affiche les points.

avant :
<img width="953" alt="Capture d’écran 2024-04-18 à 14 36 48" src="https://github.com/fab-geocommuns/RNB-site/assets/15341118/14986ec6-8c98-4a82-82fc-d264dbec9f22">

après : 
<img width="831" alt="Capture d’écran 2024-04-18 à 14 37 14" src="https://github.com/fab-geocommuns/RNB-site/assets/15341118/3d954337-dde4-4ae5-9906-3d02f5e0b6a0">

Ca vous parait acceptable comme niveau de zoom ?