### PR TITLE
Coloration syntaxique sur les blocs de code sur blog

### DIFF
--- a/app/(normalLayout)/blog/[slug]/page.tsx
+++ b/app/(normalLayout)/blog/[slug]/page.tsx
@@ -1,7 +1,14 @@
 
 
-// Lib
+// Libs
 import { getPost, formattedDate } from '@/utils/blog';
+
+// Code highlighting
+import hljs from 'highlight.js/lib/core';
+import javascript from 'highlight.js/lib/languages/javascript';
+import python from 'highlight.js/lib/languages/python';
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('python', python);
 
 // Components
 import TagsList from '@/components/blog/TagsList';
@@ -11,11 +18,19 @@ import NewsletterForm from '@/components/NewsletterForm'
 // Style
 import styles from '@/styles/blogArticle.module.scss'
 
+// Import highlight.js styles and theme
+import 'highlight.js/styles/atom-one-dark.css';
+
+//import 'highlight.js/styles/github.css';
+
+
 // SEO
 import { Metadata, ResolvingMetadata } from 'next'
 
 // Force cached parts (ghost content) to be refreshed every 10 seconds
 export const revalidate = 10
+
+
 
 async function getData(slug: string) {
     return await getPost(slug);
@@ -53,10 +68,21 @@ export default async function Page({
 
     const post = await getData(params.slug);
     const dateStr = formattedDate(post.published_at)
+
+    // find all code pre blocks in the html and replace them with highlighted code
+    const postBody = post.html.replace(/<pre><code class="language-(.*?)">([\s\S]*?)<\/code><\/pre>/g, (match, lang, code) => {
+        const highlightedCode = hljs.highlight(lang, code).value;
+        return `<pre><code class="hljs language-${lang}">${highlightedCode}</code></pre>`;
+    });
+
+    
     
     return (
         <>
             <BackToTop></BackToTop>
+
+        
+            
 
             <div className="fr-container">
 
@@ -79,7 +105,7 @@ export default async function Page({
                     </div>
                     
 
-                    <div className={styles.articleBody} dangerouslySetInnerHTML={{__html: post.html}}></div>
+                    <div className={styles.articleBody} dangerouslySetInnerHTML={{__html: postBody}}></div>
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint": "8.38.0",
         "eslint-config-next": "13.3.0",
         "events": "^3.3.0",
+        "highlight.js": "^11.9.0",
         "maplibre-gl": "^2.4.0",
         "next": "13.3.0",
         "next-auth": "^4.22.1",
@@ -2500,6 +2501,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
     "events": "^3.3.0",
+    "highlight.js": "^11.9.0",
     "maplibre-gl": "^2.4.0",
     "next": "13.3.0",
     "next-auth": "^4.22.1",

--- a/styles/blogArticle.module.scss
+++ b/styles/blogArticle.module.scss
@@ -1,4 +1,6 @@
 
+
+
 .featureImg {
     display: block;
     max-width: 100%;

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -13,6 +13,18 @@ html, body {
     height: 100%;
 }
 
+p code, 
+li code {
+    background-color: #eee;
+    color: #e40f0f;
+    
+    display: inline-block;
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.3rem;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+
 /* Pages */
 
 /* Map size */


### PR DESCRIPTION
On utilise [highlight.js](https://highlightjs.org/) pour mettre en couleur les articles de blog présentant des morceaux de code.