### PR TITLE
Meilleure UX de l'autocomplete

### DIFF
--- a/components/AddressAutocomplete.tsx
+++ b/components/AddressAutocomplete.tsx
@@ -40,6 +40,10 @@ export default function AddressAutocomplete({ autocompleteActive, query, keyDown
                         setSelectedSuggestion(selectedSuggestion - 1)
                     }
                     // select the suggestion with the enter key
+                } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    setAddressSuggestions([])
+                    setSelectedSuggestion(-1)
                 } else if (e.key === 'Enter') {
                     e.preventDefault()
                     let suggestion = null;
@@ -49,18 +53,22 @@ export default function AddressAutocomplete({ autocompleteActive, query, keyDown
                     } else if (addressSuggestions.length == 1) {
                         suggestion = addressSuggestions[0]
                     }
-                    if (suggestion) {
-                        setSuggestionChosen(true)
-                        setAddressSuggestions([])
-                        setSelectedSuggestion(-1)
-                    }
-                    onSuggestionSelected({ suggestion: suggestion })
+                    selectSuggestion(suggestion)
                 } else {
                     setSuggestionChosen(false)
                 }
             }
         }
     }, [keyDown])
+
+    const selectSuggestion = (suggestion) => {
+        if (suggestion) {
+            setSuggestionChosen(true)
+            setAddressSuggestions([])
+            setSelectedSuggestion(-1)
+        }
+        onSuggestionSelected({ suggestion: suggestion })
+    }
 
     useEffect(() => {
         if (!suggestionChosen && autocompleteActive) {
@@ -75,9 +83,7 @@ export default function AddressAutocomplete({ autocompleteActive, query, keyDown
 
                 setTypeTimeout(setTimeout(() => {
                     handleAddressQuery()
-                }, 300))
-
-                
+                }, 300))   
             }
         }
     }, [query])
@@ -112,15 +118,11 @@ export default function AddressAutocomplete({ autocompleteActive, query, keyDown
         })
     }
 
-    const select_suggestion = (suggestion) => {
-        onSuggestionSelected({ suggestion: suggestion })
-    }
-
     const suggestions = addressSuggestions.map((s, i) =>
-        <div onMouseEnter={() => setSelectedSuggestion(i)} onClick={() => select_suggestion(s)} className={styles.suggestion + ' ' + (selectedSuggestion == i ? styles.selected : '')} key={s.properties.id} >
+        <div onMouseEnter={() => setSelectedSuggestion(i)} onClick={() => selectSuggestion(s)} className={styles.suggestion + ' ' + (selectedSuggestion == i ? styles.selected : '')} key={s.properties.id} >
             {s.properties.label}
         </div >
     );
 
-    return suggestions.length > 0 ? <div className={styles.autocomplete_suggestions + ' ' + override_class}>{suggestions}</div> : null;
+    return suggestions.length > 0 && autocompleteActive ? <div className={styles.autocomplete_suggestions + ' ' + override_class}>{suggestions}</div> : null;
 }

--- a/components/AddressSearchHome.tsx
+++ b/components/AddressSearchHome.tsx
@@ -14,6 +14,7 @@ export default function AddressSearchHome() {
     const [coords, setCoords] = useState(null)
     const [keyDown, setKeyDown] = useState(null)
     const [navigateToMap, setnavigateToMap] = useState(false)
+    const [autocompleteActive, setAutocompleteActive] = useState(true)
     const formRef = useRef(null);
     const router = useRouter()
 
@@ -60,10 +61,12 @@ export default function AddressSearchHome() {
                     value={query}
                     name="q"
                     placeholder="un identifiant RNB : 1GA7PBYM1QDY ou une adresse : 42, rue des architectes, Nantes"
+                        onBlur={() => setTimeout(() => setAutocompleteActive(false), 100)}
+                        onFocus={() => setAutocompleteActive(true)}
                     />
                     <button className="fr-btn" type="submit">Rechercher</button>
                 </div>
-                <AddressAutocomplete autocompleteActive={true} query={query} keyDown={keyDown} onSuggestionSelected={handleSuggestionSelected} override_class={styles.autocomplete_suggestions}></AddressAutocomplete>
+                <AddressAutocomplete autocompleteActive={autocompleteActive} query={query} keyDown={keyDown} onSuggestionSelected={handleSuggestionSelected} override_class={styles.autocomplete_suggestions}></AddressAutocomplete>
             </div>
         </form>
     </Providers >

--- a/components/AddressSearchMap.tsx
+++ b/components/AddressSearchMap.tsx
@@ -175,6 +175,8 @@ export default function AddressSearchMap() {
                     id="address"
                     ref={addressInput}
                     onKeyDown={handleKeyDown}
+                    onBlur={() => setTimeout(() => setAutocompleteActive(false), 100)}
+                    onFocus={() => setAutocompleteActive(true)}
                 />
                 <AddressAutocomplete autocompleteActive={autocompleteActive} query={query} keyDown={keyDown} onSuggestionSelected={handleSuggestionSelected} ></AddressAutocomplete>
             </div>


### PR DESCRIPTION
Je gère ici les cas suivants qui étaient mal traités dans la PR précédente :
- quand on clique ailleurs que dans le champ de recherche, on s'attend à ce que les suggestions disparaissent
- quand on sélectionne une adresse avec la souris, on s'attend à ce que les suggestions disparaissent
- quand on appuie sur la touche Echap pendant qu'on rentre une adresse, on s'attend à ce que les suggestions disparaissent.