### PR TITLE
Email dans les signalements

### DIFF
--- a/components/ContributionForm.tsx
+++ b/components/ContributionForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 // Hooks
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 // Store
 import { useDispatch, useSelector } from "react-redux";
@@ -16,7 +16,12 @@ import styles from '@/styles/contributionForm.module.scss'
 import Button from '@codegouvfr/react-dsfr/Button';
 import Badge from '@codegouvfr/react-dsfr/Badge';
 
+// Utils
+import Cookies from 'js-cookie';
+
 export default function ContributionForm() {
+
+    
 
     const url = process.env.NEXT_PUBLIC_API_BASE + '/contributions/';
 
@@ -40,6 +45,7 @@ export default function ContributionForm() {
 
     const [sending, setSending] = useState(false)
     const [success, setSuccess] = useState(false)
+    const [email, setEmail] = useState('');
 
 
     const handleSubmit = async (e: any) => {
@@ -62,6 +68,9 @@ export default function ContributionForm() {
             setSuccess(true);
             emptyMsgInput();
 
+            /* Store email in cookie */
+            Cookies.set('email', email, { expires: 365 });
+
             va.track("contribution-success")
 
             setTimeout(() => {
@@ -72,14 +81,33 @@ export default function ContributionForm() {
         }).catch((err) => {
             va.track("contribution-error", {error: err})
         });
+
         
 
     }
 
+    const changeEmail = (e) => {
+        setEmail(e.target.value);
+    }
+    
+
+    useEffect(() => {
+
+            const storedEmail = Cookies.get('email');
+            if (storedEmail) {
+                setEmail(storedEmail);
+            }
+
+
+    }, []);
+
     return (
         <form method="post" action={url} onSubmit={handleSubmit}>
             <input name="rnb_id" type="hidden" className="fr-input" value={bdg?.rnb_id} />
-            <textarea onFocus={handleFocus} onChange={resize} ref={msgInput} required name="text" className={`fr-text--sm fr-input fr-mb-2v ${styles.msgInput}`} placeholder="Il manque un bâtiment ? Une adresse semble erronée ? Envoyez votre signalement; tout le monde peut apporter sa pierre au RNB."></textarea>
+            <textarea onFocus={handleFocus} onChange={resize} ref={msgInput} required name="text" className={`fr-text--sm fr-input fr-mb-4v ${styles.msgInput}`} placeholder="Il manque un bâtiment ? Une adresse semble erronée ? Envoyez votre signalement; tout le monde peut apporter sa pierre au RNB."></textarea>
+
+            <div className='fr-mb-1v'><label className='fr-text--sm '>Suivez le traitement de votre signalement</label></div>
+            <input onChange={changeEmail} value={email} name="email" type="email" className="fr-input fr-text--sm fr-mb-2v" placeholder="Votre adresse email (optionnelle)"  />
 
             <Button disabled={sending} size="small" type='submit'>{sending && <span>Envoi en cours ...</span>}{!sending && <span>Envoyer mon signalement</span>}</Button>
             {success && <div className='fr-mt-2v'><Badge small severity='success'>Signalement envoyé. Merci.</Badge></div>}            

--- a/components/VisuPanel.tsx
+++ b/components/VisuPanel.tsx
@@ -190,7 +190,7 @@ export default function VisuPanel() {
                 
 
                 <div className={styles.section}>
-                    <h2 className={styles.sectionTitle}>Améliorez le RNB</h2>
+                    <h2 className={styles.sectionTitle + " fr-mb-2v"}>Améliorez le RNB</h2>
                     
                     <ContributionForm />
                 </div>
@@ -214,10 +214,6 @@ export default function VisuPanel() {
                                     
                                 ))
                             )}
-
-
-                            
-
                         
                         </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-config-next": "13.3.0",
         "events": "^3.3.0",
         "highlight.js": "^11.9.0",
+        "js-cookie": "^3.0.5",
         "maplibre-gl": "^2.4.0",
         "next": "13.3.0",
         "next-auth": "^4.22.1",
@@ -2943,6 +2944,14 @@
       "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-sdsl": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint-config-next": "13.3.0",
     "events": "^3.3.0",
     "highlight.js": "^11.9.0",
+    "js-cookie": "^3.0.5",
     "maplibre-gl": "^2.4.0",
     "next": "13.3.0",
     "next-auth": "^4.22.1",


### PR DESCRIPTION
On ajoute un champs email dans les signalements. Le champs est optionnel.
A partir du moment où il a été rempli une fois, il est enregistré en cookie afin que l'utilisateur n'ait pas à le saisir plusieurs fois.