### PR TITLE
Ajout de prettier en hook pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "predev": "only-include-used-icons",
-    "prebuild": "only-include-used-icons"
+    "prepare": "husky"
   },
   "dependencies": {
     "@codegouvfr/react-dsfr": "^0.51.0",
@@ -35,6 +35,14 @@
     "yaml": "^2.3.2"
   },
   "devDependencies": {
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.7",
+    "prettier": "^3.3.2",
     "sass": "^1.66.1"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx,json,css,md}": [
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
Afin de normaliser notre style de code, je propose d'ajouter prettier (un formateur de code) en tant que pre-commit sur tous les fichiers modifiés.