### PR TITLE
Correction du clic sur une adresse de la page carte dans la liste des suggestions

### DIFF
--- a/components/AddressAutocomplete.tsx
+++ b/components/AddressAutocomplete.tsx
@@ -127,7 +127,7 @@ export default function AddressAutocomplete({
   const suggestions = addressSuggestions.map((s, i) => (
     <div
       onMouseEnter={() => setSelectedSuggestion(i)}
-      onClick={() => selectSuggestion(s)}
+      onMouseDown={() => selectSuggestion(s)}
       className={
         styles.suggestion +
         ' ' +


### PR DESCRIPTION
Lorsqu'on clique sur une suggestion d'adresse, certains navigateurs ne font pas l'action voulu