### PR TITLE
Désactiver l'animation de zoom lors de la géolocalisation pour éviter un conflit avec l'orientation.

### DIFF
--- a/components/VisuMap.tsx
+++ b/components/VisuMap.tsx
@@ -92,6 +92,8 @@ export default function VisuMap() {
       showAccuracyCircle: true,
       fitBoundsOptions: {
         maxZoom: 18,
+        animate: false,
+        duration: 0,
       },
     });
     geolocControl.on('trackuserlocationstart', () => {


### PR DESCRIPTION
Lorsque l'on clique sur la géolocalisation de la carte, celle-ci zoom sur la position actuelle.
Cette animation rentre en conflit avec l'orientation qui la stop sur une zone non voulue.