### PR TITLE
Définir une taille maximum pour la barre de progression

### DIFF
--- a/components/summerGames/homeBlock.tsx
+++ b/components/summerGames/homeBlock.tsx
@@ -44,7 +44,10 @@ export default function SummerGame() {
                 <div className={styles.bar}>
                   <div
                     className={styles.progress}
-                    style={{ width: summerGamesData.shared.percent + '%' }}
+                    style={{
+                      width:
+                        Math.min(100, summerGamesData.shared.percent) + '%',
+                    }}
                   >
                     <span className={styles.progressTotal}>
                       {summerGamesData.shared.absolute}


### PR DESCRIPTION
La taille de la barre dépasse l'élément parent si l'objectif est atteint, définissons une taille maximum (100% max).