### PR TITLE
Correction de la couche des bâtiments lors du changement de style de la carte

### DIFF
--- a/components/map/MapStyleSwitcher.ts
+++ b/components/map/MapStyleSwitcher.ts
@@ -1,3 +1,8 @@
+import {
+  BUILDINGS_LAYER,
+  BUILDINGS_SOURCE,
+} from '@/components/map/useMapLayers';
+
 export default class MapStyleSwitcherControl {
   constructor(options) {
     this._options = { ...options };
@@ -48,7 +53,25 @@ export default class MapStyleSwitcherControl {
 
   setStyle(styleKey) {
     this._options.chosenStyle = styleKey;
-    this._map.setStyle(this._options.styles[styleKey].style);
+
+    // On garde la source et la couche des bâtiments
+    const currentStyle = this._map.getStyle();
+    const sourceBatiments = currentStyle.sources[BUILDINGS_SOURCE];
+    const coucheBatiments = currentStyle.layers.find(
+      (l) => l.id === BUILDINGS_LAYER,
+    );
+
+    // On duplique notre style pour ne pas modifier le style initial
+    const newStyle = JSON.parse(
+      JSON.stringify(this._options.styles[styleKey].style),
+    );
+
+    if (sourceBatiments && coucheBatiments) {
+      newStyle.sources[BUILDINGS_SOURCE] = sourceBatiments;
+      newStyle.layers.push(coucheBatiments);
+    }
+
+    this._map.setStyle(newStyle);
 
     const otherStyleKey = this.theOtherStyleKey(styleKey);
 

--- a/components/map/MapStyleSwitcher.ts
+++ b/components/map/MapStyleSwitcher.ts
@@ -56,8 +56,8 @@ export default class MapStyleSwitcherControl {
 
     // On garde la source et la couche des bâtiments
     const currentStyle = this._map.getStyle();
-    const sourceBatiments = currentStyle.sources[BUILDINGS_SOURCE];
-    const coucheBatiments = currentStyle.layers.find(
+    const buildingSource = currentStyle.sources[BUILDINGS_SOURCE];
+    const buildingLayers = currentStyle.layers.find(
       (l) => l.id === BUILDINGS_LAYER,
     );
 
@@ -66,9 +66,9 @@ export default class MapStyleSwitcherControl {
       JSON.stringify(this._options.styles[styleKey].style),
     );
 
-    if (sourceBatiments && coucheBatiments) {
-      newStyle.sources[BUILDINGS_SOURCE] = sourceBatiments;
-      newStyle.layers.push(coucheBatiments);
+    if (buildingSource && buildingLayers) {
+      newStyle.sources[BUILDINGS_SOURCE] = buildingSource;
+      newStyle.layers.push(buildingLayers);
     }
 
     this._map.setStyle(newStyle);


### PR DESCRIPTION
Lorsque l'on change le style de la carte (Plan <=>  Satellite), la couche des bâtiments disparait.
Cette PR permet de la garder après le changement de style.