### PR TITLE
Ajout de l'identifiant BAN lors de la sélection d'un bâtiment

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,7 @@
 # NEXT_PUBLIC_API_BASE
 # NB: No trailing slash
 NEXT_PUBLIC_API_BASE=https://rnb-api.beta.gouv/fr/api/alpha
+NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
 
 # NEXT_PUBLIC_HEAP_ID
 # The site/env id in Heap Analytics

--- a/components/VisuPanel.tsx
+++ b/components/VisuPanel.tsx
@@ -164,7 +164,8 @@ export default function VisuPanel() {
                       {a.city_zipcode} {a.city_name}
                       <br />
                       <small>
-                        (Clé nationale d&apos;interopérabilité BAN : {a.id})
+                        ({a.banId ? `Identifiant BAN : ${a.banId}, c` : 'C'}lé
+                        nationale d&apos;interopérabilité BAN : {a.id})
                       </small>
                     </div>
                   ))


### PR DESCRIPTION
En attendant d'importer les identifiants BAN au format UUID qui ne sont pas encore positionnés sur tous les bâtiments et qui ont pour vocation à remplacer la clé d'interopérabilité, nous avons décidé d'afficher cette clé lors de la sélection d'un bâtiment sur la carte.