### PR TITLE
Bug affichage adresse

### DIFF
--- a/components/VisuPanel.tsx
+++ b/components/VisuPanel.tsx
@@ -164,8 +164,15 @@ export default function VisuPanel() {
                       {a.city_zipcode} {a.city_name}
                       <br />
                       <small>
-                        ({a.banId ? `Identifiant BAN : ${a.banId}, c` : 'C'}lé
-                        nationale d&apos;interopérabilité BAN : {a.id})
+                        Clé BAN : {a.id}
+                        {a.banId ? (
+                          <>
+                            <br />
+                            Identifiant BAN : {a.banId}
+                          </>
+                        ) : (
+                          ''
+                        )}
                       </small>
                     </div>
                   ))


### PR DESCRIPTION
On avait un souci lié à la récupération de l'UUID BAN.
Si on consultait deux bâtiment successivement, il pouvait arriver que le deuxième bâtiment voit ses adresses modifiées et se retrouvent avec l'adresse du premier bâtiment. Le souci vient du temps de chargement de l'info en provenance de l'API de la BAN.

Pour parer à cela, j'ai simplement ajouter une condition : on met à jour les adresse uniquement si le rnb_id correspondant au moment de la requête est le même que le rnb_id qu'on consulte au moment du retour de la requête.