### PR TITLE
Fix de la vue satellite

### DIFF
--- a/components/map/mapstyles/satellite.json
+++ b/components/map/mapstyles/satellite.json
@@ -5,7 +5,7 @@
     "raster-tiles": {
       "type": "raster",
       "tiles": [
-        "https://wxs.ign.fr/essentiels/geoportail/wmts?layer=ORTHOIMAGERY.ORTHOPHOTOS&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}"
+        "https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&STYLE=normal&FORMAT=image/jpeg&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
       ],
       "tileSize": 256,
       "attribution": "<a target='_blank' href='https://geoservices.ign.fr/documentation/donnees/ortho/bdortho' /> © IGN </a>"


### PR DESCRIPTION
L'ancienne url IGN ne semble plus fonctionner. Je la remplace.
Aussi, je teste le résumé de PR par Copilot ⏬  😅 

----

This pull request includes a change to the `components/map/mapstyles/satellite.json` file. The change updates the URL for the raster tiles used in the satellite map style.

* [`components/map/mapstyles/satellite.json`](diffhunk://#diff-d1659e4e14be4149170c4a451eaa87d121f35e3521791495d1475acd49a9930fL8-R8): Updated the URL for the raster tiles from `https://wxs.ign.fr/essentiels/geoportail/wmts` to `https://data.geopf.fr/wmts` to ensure compatibility and access to the latest imagery.