### PR TITLE
Modifications pour ADS

### DIFF
--- a/components/map/MapStyleSwitcher.ts
+++ b/components/map/MapStyleSwitcher.ts
@@ -2,7 +2,6 @@ import {
   BUILDINGS_LAYER,
   BUILDINGS_SOURCE,
 } from '@/components/map/useMapLayers';
-import { current } from 'immer';
 
 export default class MapStyleSwitcherControl {
   constructor(options) {
@@ -58,20 +57,39 @@ export default class MapStyleSwitcherControl {
     // On garde la source et la couche des bâtiments
     const currentStyle = this._map.getStyle();
 
-    const buildingSource = currentStyle?.sources[BUILDINGS_SOURCE];
-    const buildingLayers = currentStyle?.layers.find(
-      (l) => l.id === BUILDINGS_LAYER,
-    );
+    const sourcesIdsToKeep = [BUILDINGS_SOURCE, 'ads'];
+    const layersIdsToKeep = [BUILDINGS_LAYER, 'adscircle', 'adsicon'];
+
+    const sourcesToKeep = {};
+    const layersToKeep = [];
+
+    // Copy sources
+    sourcesIdsToKeep.forEach((sourceId: string) => {
+      if (currentStyle.sources[sourceId]) {
+        sourcesToKeep[sourceId] = currentStyle.sources[sourceId];
+      }
+    });
+
+    // Copy layers
+    currentStyle.layers.forEach((layer) => {
+      if (layersIdsToKeep.includes(layer.id)) {
+        layersToKeep.push(layer);
+      }
+    });
 
     // On duplique notre style pour ne pas modifier le style initial
     const newStyle = JSON.parse(
       JSON.stringify(this._options.styles[styleKey].style),
     );
 
-    if (buildingSource && buildingLayers) {
-      newStyle.sources[BUILDINGS_SOURCE] = buildingSource;
-      newStyle.layers.push(buildingLayers);
-    }
+    // On remplace les sources et les layers
+    Object.keys(sourcesToKeep).forEach((sourceId) => {
+      newStyle.sources[sourceId] = sourcesToKeep[sourceId];
+    });
+
+    layersToKeep.forEach((layer) => {
+      newStyle.layers.push(layer);
+    });
 
     this._map.setStyle(newStyle);
 

--- a/components/map/map.utils.ts
+++ b/components/map/map.utils.ts
@@ -15,7 +15,7 @@ export const getNearestFeatureFromCursorWithBuffer = (
   y: number,
   buffer = 15,
 ): MapGeoJSONFeature | undefined => {
-  //if (!map.getLayer(BUILDINGS_LAYER) && !map.getLayer('adscircle')) return;
+  if (!map.getLayer(BUILDINGS_LAYER) && !map.getLayer('adscircle')) return;
 
   const bbox: [PointLike, PointLike] = [
     [x - buffer, y - buffer],

--- a/components/map/map.utils.ts
+++ b/components/map/map.utils.ts
@@ -15,7 +15,7 @@ export const getNearestFeatureFromCursorWithBuffer = (
   y: number,
   buffer = 15,
 ): MapGeoJSONFeature | undefined => {
-  if (!map.getLayer(BUILDINGS_LAYER) || !map.getLayer('adscircle')) return;
+  //if (!map.getLayer(BUILDINGS_LAYER) && !map.getLayer('adscircle')) return;
 
   const bbox: [PointLike, PointLike] = [
     [x - buffer, y - buffer],

--- a/components/map/useMapEvents.ts
+++ b/components/map/useMapEvents.ts
@@ -23,6 +23,8 @@ export const useMapEvents = (map?: maplibregl.Map) => {
     if (map) {
       // Click sur la carte
       map.on('click', async function (e) {
+        console.log('click on map');
+
         const featureCloseToCursor = getNearestFeatureFromCursorWithBuffer(
           map,
           e.point.x,

--- a/components/map/useMapEvents.ts
+++ b/components/map/useMapEvents.ts
@@ -23,8 +23,6 @@ export const useMapEvents = (map?: maplibregl.Map) => {
     if (map) {
       // Click sur la carte
       map.on('click', async function (e) {
-        console.log('click on map');
-
         const featureCloseToCursor = getNearestFeatureFromCursorWithBuffer(
           map,
           e.point.x,

--- a/components/map/useMapLayers.ts
+++ b/components/map/useMapLayers.ts
@@ -9,7 +9,7 @@ import { RootState } from '@/stores/map/store';
 const BDGS_TILES_URL =
   process.env.NEXT_PUBLIC_API_BASE + '/tiles/{x}/{y}/{z}.pbf';
 const ADS_TILES_URL =
-  process.env.NEXT_PUBLIC_API_BASE + '/ads/tiles/{x}/{y}/{z}.pbf';
+  process.env.NEXT_PUBLIC_API_BASE + '/permis/tiles/{x}/{y}/{z}.pbf';
 export const BUILDINGS_SOURCE = 'bdgtiles';
 export const BUILDINGS_LAYER = 'bdgs';
 

--- a/components/map/useMapLayers.ts
+++ b/components/map/useMapLayers.ts
@@ -75,8 +75,8 @@ export const useMapLayers = (map?: maplibregl.Map) => {
         'circle-radius': [
           'case',
           ['boolean', ['==', ['feature-state', 'hovered'], true]],
-          14,
           12,
+          10,
         ],
         'circle-stroke-color': [
           'case',
@@ -106,7 +106,7 @@ export const useMapLayers = (map?: maplibregl.Map) => {
           'adsModify',
           'adsBuild',
         ],
-        'icon-size': 0.25,
+        'icon-size': 0.2,
         'icon-allow-overlap': true,
         'icon-ignore-placement': true,
       },

--- a/stores/map/slice.tsx
+++ b/stores/map/slice.tsx
@@ -185,7 +185,7 @@ export const addBanUUID = createAsyncThunk(
 );
 
 export function adsApiUrl(fileNumber: string) {
-  return process.env.NEXT_PUBLIC_API_BASE + '/ads/' + fileNumber;
+  return process.env.NEXT_PUBLIC_API_BASE + '/permis/' + fileNumber + '/';
 }
 
 export function bdgApiUrl(bdgId: string) {


### PR DESCRIPTION
- debug : les bâtiment n'étaient plus cliquables après le passage en vue aérienne
- debug : les icones d'ADS n'étaient plus visibles après le passage en vue aérienne
- adblocker : utilisation des urls contenant `/permis/` plutôt que celle contenant `/ads/` (cf [PR482](https://github.com/fab-geocommuns/RNB-coeur/pull/482) dans rnb-coeur)
- légère réduction de la taille des icônes d'ADS