### PR TITLE
Rajouter le lien d'explication pour les constructions provisoires

### DIFF
--- a/data/building-list.yaml
+++ b/data/building-list.yaml
@@ -99,6 +99,7 @@
   image: tunnel.png
 
 - id: construction-provisoire
+  description: <a href="#construction-provisoire">voir les explications.</a>
   title: Construction provisoire
   image: construction-provisoire.jpeg
   distinctionBetweenSingleAndMultipleText: Au vu des critères donnés par la définition, le caractère permanent pourra être évalué par chaque contributeur. Par exemple, une construction provisoire érigée pour une durée excédant une durée réglementaire (qui peut varier selon les cas) et qui est solidement fixés au sol, est considérée comme un bâtiment.


### PR DESCRIPTION
Comme remonté ici https://www.notion.so/referentielnationaldesbatiments/Page-D-finition-absence-lien-explications-sur-construction-provisoire-17643ec9d11e80bbbb14d2ec2f9dfbb0