### PR TITLE
Extract AddressInput

### DIFF
--- a/app/(normalLayout)/playground/page.tsx
+++ b/app/(normalLayout)/playground/page.tsx
@@ -14,9 +14,6 @@ export default function PlaygroundPage() {
       )}
       {displayInput && (
         <AddressInput
-          onEnterPress={() => {
-            alert('enter pressed');
-          }}
           onSuggestionSelected={(suggestion) => {
             alert('suggestion selected ' + JSON.stringify(suggestion));
           }}
@@ -30,6 +27,15 @@ export default function PlaygroundPage() {
               style={{ width: '240px', border: '1px solid red' }}
             />
           )}
+          renderSuggestion={(suggestion) => (
+            <span style={{ border: '1px dotted green' }}>
+              {suggestion.properties.label} (clé ban: {suggestion.properties.id}
+              )
+            </span>
+          )}
+          geocodeQueryParams={{
+            postcode: '75020',
+          }}
         />
       )}
     </div>

--- a/app/(normalLayout)/playground/page.tsx
+++ b/app/(normalLayout)/playground/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import AddressInput from '@/components/address/AddressInput';
+import { useState } from 'react';
+
+export default function PlaygroundPage() {
+  const [displayInput, setDisplayInput] = useState(false);
+  return (
+    <div>
+      {!displayInput && (
+        <a href="#" onClick={() => setDisplayInput(true)}>
+          Show input
+        </a>
+      )}
+      {displayInput && (
+        <AddressInput
+          onEnterPress={() => {
+            alert('enter pressed');
+          }}
+          onSuggestionSelected={(suggestion) => {
+            alert('suggestion selected ' + JSON.stringify(suggestion));
+          }}
+          onEscapePress={() => {
+            setDisplayInput(false);
+          }}
+          render={(props) => (
+            <input
+              {...props}
+              autoFocus
+              style={{ width: '240px', border: '1px solid red' }}
+            />
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(normalLayout)/playground/page.tsx
+++ b/app/(normalLayout)/playground/page.tsx
@@ -17,6 +17,11 @@ export default function PlaygroundPage() {
           onSuggestionSelected={(suggestion) => {
             alert('suggestion selected ' + JSON.stringify(suggestion));
           }}
+          onQueryResults={(query, results) => {
+            return results.sort((a, b) =>
+              a.properties.id.localeCompare(b.properties.id),
+            );
+          }}
           onEscapePress={() => {
             setDisplayInput(false);
           }}

--- a/components/address/AddressAutocomplete.tsx
+++ b/components/address/AddressAutocomplete.tsx
@@ -34,7 +34,7 @@ type Props = {
   query: string;
   keyDown: React.KeyboardEvent | null;
   onSuggestionSelected: (suggestion: AddressSuggestion) => void;
-  overrideClassName?: string;
+  additionalClassName?: string;
   onQueryResults?: (query: string, results: AddressSuggestion[]) => void;
   renderSuggestion?: (suggestion: AddressSuggestion) => React.ReactNode;
   geocodeQueryParams?: Record<string, string>;
@@ -45,7 +45,7 @@ export default function AddressAutocomplete({
   query,
   keyDown,
   onSuggestionSelected,
-  overrideClassName = '',
+  additionalClassName = '',
   onQueryResults,
   renderSuggestion = (suggestion: AddressSuggestion) =>
     suggestion.properties.label,
@@ -181,7 +181,9 @@ export default function AddressAutocomplete({
   ));
 
   return suggestions.length > 0 && autocompleteActive ? (
-    <div className={styles.autocomplete_suggestions + ' ' + overrideClassName}>
+    <div
+      className={styles.autocomplete_suggestions + ' ' + additionalClassName}
+    >
       {suggestions}
     </div>
   ) : null;

--- a/components/address/AddressAutocomplete.tsx
+++ b/components/address/AddressAutocomplete.tsx
@@ -1,33 +1,68 @@
 'use client';
 
 // Hooks
-import { useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useState, useEffect, useRef } from 'react';
 
 import styles from '@/styles/addressAutocomplete.module.scss';
-import { Actions } from '@/stores/store';
+
+import { Feature, FeatureCollection, Point } from 'geojson';
+
+type BANAddressAttributes = {
+  id: string;
+  label: string;
+  housenumber: string;
+  street: string;
+  city: string;
+  citycode: string;
+  context: string;
+  district: string;
+  postcode: string;
+  score: number;
+  name: string;
+  type: string;
+  x: number;
+  y: number;
+  importance: number;
+};
+
+export type AddressSuggestion = Feature<Point, BANAddressAttributes>;
+
+type BANGeocodingResult = FeatureCollection<Point, BANAddressAttributes>;
+
+type Props = {
+  autocompleteActive: boolean;
+  query: string;
+  keyDown: React.KeyboardEvent | null;
+  onSuggestionSelected: (suggestion: AddressSuggestion) => void;
+  overrideClassName?: string;
+  onQueryResults?: (query: string, results: AddressSuggestion[]) => void;
+  renderSuggestion?: (suggestion: AddressSuggestion) => React.ReactNode;
+  geocodeQueryParams?: Record<string, string>;
+};
 
 export default function AddressAutocomplete({
-  // @ts-ignore
   autocompleteActive,
-  // @ts-ignore
   query,
-  // @ts-ignore
   keyDown,
-  // @ts-ignore
   onSuggestionSelected,
-  override_class = '',
-}) {
+  overrideClassName = '',
+  onQueryResults,
+  renderSuggestion = (suggestion: AddressSuggestion) =>
+    suggestion.properties.label,
+  geocodeQueryParams = {},
+}: Props) {
   // contains the address suggestions given by the BAN API
-  const [addressSuggestions, setAddressSuggestions] = useState([]);
+  const [addressSuggestions, setAddressSuggestions] = useState<
+    AddressSuggestion[]
+  >([]);
   // used to highlight and choose an address suggestion
-  const [selectedSuggestion, setSelectedSuggestion] = useState(-1);
+  const [highlightedSuggestionIndex, setHighlightedSuggestionIndex] =
+    useState(-1);
 
-  const [typeTimeout, setTypeTimeout] = useState(null);
+  const typeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // when a suggestion is chosen, this is set to true to prevent an extra call the the API
   const [suggestionChosen, setSuggestionChosen] = useState(false);
-  const dispatch = useDispatch();
   const apiUrl = 'https://api-adresse.data.gouv.fr/search/';
 
   useEffect(() => {
@@ -37,24 +72,27 @@ export default function AddressAutocomplete({
         // pick the suggestion with the arrow keys
         if (e.key === 'ArrowDown') {
           e.preventDefault();
-          if (selectedSuggestion < addressSuggestions.length - 1) {
-            setSelectedSuggestion(selectedSuggestion + 1);
+          if (highlightedSuggestionIndex < addressSuggestions.length - 1) {
+            setHighlightedSuggestionIndex(highlightedSuggestionIndex + 1);
           }
         } else if (e.key === 'ArrowUp') {
           e.preventDefault();
-          if (selectedSuggestion > 0) {
-            setSelectedSuggestion(selectedSuggestion - 1);
+          if (highlightedSuggestionIndex > 0) {
+            setHighlightedSuggestionIndex(highlightedSuggestionIndex - 1);
           }
           // select the suggestion with the enter key
         } else if (e.key === 'Escape') {
           e.preventDefault();
           setAddressSuggestions([]);
-          setSelectedSuggestion(-1);
+          setHighlightedSuggestionIndex(-1);
         } else if (e.key === 'Enter') {
           e.preventDefault();
           let suggestion = null;
-          if (addressSuggestions.length > 1 && selectedSuggestion >= 0) {
-            suggestion = addressSuggestions[selectedSuggestion];
+          if (
+            addressSuggestions.length > 1 &&
+            highlightedSuggestionIndex >= 0
+          ) {
+            suggestion = addressSuggestions[highlightedSuggestionIndex];
             // you don't need to select a suggestion if there is only one
           } else if (addressSuggestions.length == 1) {
             suggestion = addressSuggestions[0];
@@ -67,60 +105,54 @@ export default function AddressAutocomplete({
     }
   }, [keyDown]);
 
-  // @ts-ignore
-  const selectSuggestion = (suggestion) => {
+  const selectSuggestion = (suggestion: AddressSuggestion | null) => {
     if (suggestion) {
       setSuggestionChosen(true);
       setAddressSuggestions([]);
-      setSelectedSuggestion(-1);
+      setHighlightedSuggestionIndex(-1);
+      onSuggestionSelected(suggestion);
     }
-    onSuggestionSelected({ suggestion: suggestion });
   };
 
   useEffect(() => {
     if (!suggestionChosen && autocompleteActive) {
-      setSelectedSuggestion(-1);
+      setHighlightedSuggestionIndex(-1);
       if (query.length < 3) {
         setAddressSuggestions([]);
       } else {
-        if (typeTimeout) {
-          clearTimeout(typeTimeout);
+        if (typeTimeoutRef.current) {
+          clearTimeout(typeTimeoutRef.current);
         }
 
-        setTypeTimeout(
-          // @ts-ignore
-          setTimeout(() => {
-            handleAddressQuery();
-          }, 300),
-        );
+        typeTimeoutRef.current = setTimeout(() => {
+          handleAddressQuery();
+        }, 300);
       }
     }
   }, [query]);
 
   const handleAddressQuery = async () => {
-    // Add the query to the store
+    const geocodingResult = (await fetchBanAPI(query)) as BANGeocodingResult;
 
-    const geocode_result = await fetchBanAPI(query);
-
-    dispatch(Actions.map.setAddressSearchQuery(query));
-    // @ts-ignore
-    dispatch(Actions.map.setAddressSearchResults(geocode_result.features));
-    // @ts-ignore
-    if (geocode_result.features && geocode_result.features.length > 0) {
-      // @ts-ignore
-      setAddressSuggestions(geocode_result.features);
-      setSelectedSuggestion(-1);
+    if (onQueryResults) {
+      onQueryResults(query, geocodingResult.features);
     }
-    // @ts-ignore
-    return geocode_result.features;
+    if (geocodingResult.features && geocodingResult.features.length > 0) {
+      setAddressSuggestions(geocodingResult.features);
+      setHighlightedSuggestionIndex(-1);
+    }
+    return geocodingResult.features;
   };
 
-  // @ts-ignore
-  const fetchBanAPI = async (q) => {
+  const fetchBanAPI = async (q: string) => {
     let query_url = new URL(apiUrl);
     query_url.searchParams.set('q', q);
-    // @ts-ignore
-    query_url.searchParams.set('autocomplete', 1);
+    query_url.searchParams.set('autocomplete', '1');
+
+    Object.keys(geocodeQueryParams).forEach((key) => {
+      query_url.searchParams.set(key, geocodeQueryParams[key]);
+    });
+
     return new Promise((resolve, reject) => {
       fetch(query_url)
         .then((response) => response.json())
@@ -135,23 +167,21 @@ export default function AddressAutocomplete({
 
   const suggestions = addressSuggestions.map((s, i) => (
     <div
-      onMouseEnter={() => setSelectedSuggestion(i)}
+      onMouseEnter={() => setHighlightedSuggestionIndex(i)}
       onMouseDown={() => selectSuggestion(s)}
       className={
         styles.suggestion +
         ' ' +
-        (selectedSuggestion == i ? styles.selected : '')
+        (highlightedSuggestionIndex == i ? styles.selected : '')
       }
-      // @ts-ignore
       key={s.properties.id}
     >
-      {/* @ts-ignore */}
-      {s.properties.label}
+      {renderSuggestion(s)}
     </div>
   ));
 
   return suggestions.length > 0 && autocompleteActive ? (
-    <div className={styles.autocomplete_suggestions + ' ' + override_class}>
+    <div className={styles.autocomplete_suggestions + ' ' + overrideClassName}>
       {suggestions}
     </div>
   ) : null;

--- a/components/address/AddressAutocomplete.tsx
+++ b/components/address/AddressAutocomplete.tsx
@@ -19,7 +19,7 @@ type BANAddressAttributes = {
   postcode: string;
   score: number;
   name: string;
-  type: string;
+  type: 'housenumber' | 'street' | 'locality' | 'municipality';
   x: number;
   y: number;
   importance: number;
@@ -35,7 +35,10 @@ type Props = {
   keyDown: React.KeyboardEvent | null;
   onSuggestionSelected: (suggestion: AddressSuggestion) => void;
   additionalClassName?: string;
-  onQueryResults?: (query: string, results: AddressSuggestion[]) => void;
+  onQueryResults?: (
+    query: string,
+    results: AddressSuggestion[],
+  ) => void | AddressSuggestion[];
   renderSuggestion?: (suggestion: AddressSuggestion) => React.ReactNode;
   geocodeQueryParams?: Record<string, string>;
 };
@@ -134,14 +137,18 @@ export default function AddressAutocomplete({
   const handleAddressQuery = async () => {
     const geocodingResult = (await fetchBanAPI(query)) as BANGeocodingResult;
 
-    if (onQueryResults) {
-      onQueryResults(query, geocodingResult.features);
+    let results = geocodingResult.features;
+    if (results && onQueryResults) {
+      const newResults = onQueryResults(query, geocodingResult.features);
+      if (newResults) {
+        results = newResults;
+      }
     }
-    if (geocodingResult.features && geocodingResult.features.length > 0) {
-      setAddressSuggestions(geocodingResult.features);
+    if (results && results.length > 0) {
+      setAddressSuggestions(results);
       setHighlightedSuggestionIndex(-1);
     }
-    return geocodingResult.features;
+    return results;
   };
 
   const fetchBanAPI = async (q: string) => {

--- a/components/address/AddressInput.tsx
+++ b/components/address/AddressInput.tsx
@@ -38,6 +38,16 @@ export default function AddressInput({
   const [query, setQuery] = useState('');
   const [keyDown, setKeyDown] = useState<React.KeyboardEvent | null>(null);
 
+  const handleEscapePress = () => {
+    if (autocompleteActive) {
+      setAutocompleteActive(false);
+    }
+
+    if (!autocompleteActive || query == '') {
+      onEscapePress?.();
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     setKeyDown(e);
 
@@ -45,16 +55,8 @@ export default function AddressInput({
       onEnterPress();
     }
 
-    if (e.key === 'Escape' && autocompleteActive) {
-      setAutocompleteActive(false);
-    }
-
-    if (
-      e.key === 'Escape' &&
-      (!autocompleteActive || query == '') &&
-      onEscapePress
-    ) {
-      onEscapePress();
+    if (e.key === 'Escape') {
+      handleEscapePress();
     }
   };
 
@@ -63,7 +65,7 @@ export default function AddressInput({
     onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
       setQuery(e.target.value),
     onKeyDown: (e: React.KeyboardEvent) => handleKeyDown(e),
-    onBlur: () => setTimeout(() => setAutocompleteActive(false), 100),
+    onBlur: () => setTimeout(() => handleEscapePress(), 100),
     onFocus: () => setAutocompleteActive(true),
     type: 'text',
     autoComplete: 'off',

--- a/components/address/AddressInput.tsx
+++ b/components/address/AddressInput.tsx
@@ -18,6 +18,10 @@ type Props = {
   }) => React.ReactNode;
   renderSuggestion?: (suggestion: AddressSuggestion) => React.ReactNode;
   geocodeQueryParams?: Record<string, string>;
+  onQueryResults?: (
+    query: string,
+    suggestions: AddressSuggestion[],
+  ) => void | AddressSuggestion[];
 };
 
 export default function AddressInput({
@@ -27,6 +31,7 @@ export default function AddressInput({
   additionalSuggestionsClassname,
   render,
   renderSuggestion,
+  onQueryResults,
   geocodeQueryParams,
 }: Props) {
   const [autocompleteActive, setAutocompleteActive] = useState(false);
@@ -78,6 +83,7 @@ export default function AddressInput({
         query={query}
         keyDown={keyDown}
         onSuggestionSelected={handleSuggestionSelected}
+        onQueryResults={onQueryResults}
         additionalClassName={additionalSuggestionsClassname}
         renderSuggestion={renderSuggestion}
         geocodeQueryParams={geocodeQueryParams}

--- a/components/address/AddressInput.tsx
+++ b/components/address/AddressInput.tsx
@@ -8,7 +8,7 @@ type Props = {
   onSuggestionSelected: (suggestion: AddressSuggestion) => void;
   onEnterPress?: () => void;
   onEscapePress?: () => void;
-  overrideSuggestionsClassname?: string;
+  additionalSuggestionsClassname?: string;
   render: (inputProps: {
     value: string;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -24,7 +24,7 @@ export default function AddressInput({
   onSuggestionSelected,
   onEnterPress,
   onEscapePress,
-  overrideSuggestionsClassname,
+  additionalSuggestionsClassname,
   render,
   renderSuggestion,
   geocodeQueryParams,
@@ -78,7 +78,7 @@ export default function AddressInput({
         query={query}
         keyDown={keyDown}
         onSuggestionSelected={handleSuggestionSelected}
-        overrideClassName={overrideSuggestionsClassname}
+        additionalClassName={additionalSuggestionsClassname}
         renderSuggestion={renderSuggestion}
         geocodeQueryParams={geocodeQueryParams}
       ></AddressAutocomplete>

--- a/components/address/AddressInput.tsx
+++ b/components/address/AddressInput.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+// Components
+import AddressAutocomplete, { AddressSuggestion } from './AddressAutocomplete';
+import { useState } from 'react';
+
+type Props = {
+  onSuggestionSelected: (suggestion: AddressSuggestion) => void;
+  onEnterPress?: () => void;
+  onEscapePress?: () => void;
+  overrideSuggestionsClassname?: string;
+  render: (inputProps: {
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onKeyDown: (e: React.KeyboardEvent) => void;
+    onBlur: () => void;
+    onFocus: () => void;
+  }) => React.ReactNode;
+  renderSuggestion?: (suggestion: AddressSuggestion) => React.ReactNode;
+  geocodeQueryParams?: Record<string, string>;
+};
+
+export default function AddressInput({
+  onSuggestionSelected,
+  onEnterPress,
+  onEscapePress,
+  overrideSuggestionsClassname,
+  render,
+  renderSuggestion,
+  geocodeQueryParams,
+}: Props) {
+  const [autocompleteActive, setAutocompleteActive] = useState(false);
+  const [query, setQuery] = useState('');
+  const [keyDown, setKeyDown] = useState<React.KeyboardEvent | null>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    setKeyDown(e);
+
+    if (e.key === 'Enter' && onEnterPress) {
+      onEnterPress();
+    }
+
+    if (e.key === 'Escape' && autocompleteActive) {
+      setAutocompleteActive(false);
+    }
+
+    if (
+      e.key === 'Escape' &&
+      (!autocompleteActive || query == '') &&
+      onEscapePress
+    ) {
+      onEscapePress();
+    }
+  };
+
+  const renderedInputProps = {
+    value: query,
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+      setQuery(e.target.value),
+    onKeyDown: (e: React.KeyboardEvent) => handleKeyDown(e),
+    onBlur: () => setTimeout(() => setAutocompleteActive(false), 100),
+    onFocus: () => setAutocompleteActive(true),
+    type: 'text',
+    autoComplete: 'off',
+    'data-1p-ignore': true,
+  };
+
+  const handleSuggestionSelected = (suggestion: AddressSuggestion) => {
+    setQuery(suggestion?.properties.label);
+    onSuggestionSelected(suggestion);
+  };
+
+  return (
+    <>
+      {render(renderedInputProps)}
+      <AddressAutocomplete
+        autocompleteActive={autocompleteActive}
+        query={query}
+        keyDown={keyDown}
+        onSuggestionSelected={handleSuggestionSelected}
+        overrideClassName={overrideSuggestionsClassname}
+        renderSuggestion={renderSuggestion}
+        geocodeQueryParams={geocodeQueryParams}
+      ></AddressAutocomplete>
+    </>
+  );
+}

--- a/components/address/AddressSearchHome.tsx
+++ b/components/address/AddressSearchHome.tsx
@@ -13,15 +13,13 @@ export default function AddressSearchHome() {
   const formRef = useRef(null);
   const router = useRouter();
 
-  const handleSuggestionSelected = (suggestion: AddressSuggestion | null) => {
-    if (suggestion !== null) {
-      const query = suggestion.properties.label;
-      const coords = `${suggestion.geometry.coordinates[1]},${suggestion.geometry.coordinates[0]}`;
-      const params = new URLSearchParams();
-      params.append('q', query);
-      params.append('coords', coords);
-      router.push(`/carte?${params.toString()}`);
-    }
+  const handleSuggestionSelected = (suggestion: AddressSuggestion) => {
+    const query = suggestion.properties.label;
+    const coords = `${suggestion.geometry.coordinates[1]},${suggestion.geometry.coordinates[0]}`;
+    const params = new URLSearchParams();
+    params.append('q', query);
+    params.append('coords', coords);
+    router.push(`/carte?${params.toString()}`);
   };
 
   return (
@@ -31,12 +29,11 @@ export default function AddressSearchHome() {
           <div className="fr-search-bar">
             <AddressInput
               onSuggestionSelected={handleSuggestionSelected}
-              overrideSuggestionsClassname={styles.autocomplete_suggestions}
+              additionalSuggestionsClassname={styles.autocomplete_suggestions}
               render={(inputProps: any) => (
                 <>
                   <input
                     className="fr-input"
-                    data-1p-ignore
                     name="q"
                     placeholder="Un identifiant RNB : 1GA7PBYM1QDY ou une adresse : 42, rue des architectes, Nantes"
                     {...inputProps}

--- a/components/address/AddressSearchHome.tsx
+++ b/components/address/AddressSearchHome.tsx
@@ -1,81 +1,53 @@
 'use client';
 
-import { useState, useRef, use, useEffect } from 'react';
+import { useRef } from 'react';
 import { Providers } from '@/stores/provider';
 import { useRouter } from 'next/navigation';
 
-import AddressAutocomplete from './AddressAutocomplete';
+import { AddressSuggestion } from '@/components/address/AddressAutocomplete';
+import AddressInput from '@/components/address/AddressInput';
 
 import styles from '@/styles/home.module.scss';
 
 export default function AddressSearchHome() {
-  const [query, setQuery] = useState('');
-  const [coords, setCoords] = useState(null);
-  const [keyDown, setKeyDown] = useState(null);
-  const [navigateToMap, setnavigateToMap] = useState(false);
-  const [autocompleteActive, setAutocompleteActive] = useState(true);
   const formRef = useRef(null);
   const router = useRouter();
 
-  // @ts-ignore
-  const handleKeyDown = (e) => {
-    setKeyDown(e);
-  };
-
-  // @ts-ignore
-  const handleSuggestionSelected = ({ suggestion }) => {
+  const handleSuggestionSelected = (suggestion: AddressSuggestion | null) => {
     if (suggestion !== null) {
-      setQuery(suggestion.properties.label);
-      setCoords(
-        // @ts-ignore
-        `${suggestion.geometry.coordinates[1]},${suggestion.geometry.coordinates[0]}`,
-      );
-    }
-    setnavigateToMap(true);
-  };
-
-  useEffect(() => {
-    if (navigateToMap) {
-      let params = new URLSearchParams();
-      if (query) {
-        params.append('q', query);
-      }
-      if (coords) {
-        params.append('coords', coords);
-      }
+      const query = suggestion.properties.label;
+      const coords = `${suggestion.geometry.coordinates[1]},${suggestion.geometry.coordinates[0]}`;
+      const params = new URLSearchParams();
+      params.append('q', query);
+      params.append('coords', coords);
       router.push(`/carte?${params.toString()}`);
     }
-  }, [navigateToMap]);
+  };
 
   return (
     <Providers>
       <form action="/carte" method="get" ref={formRef}>
         <div className={styles['home-search-bar-wrapper']}>
           <div className="fr-search-bar">
-            <input
-              className="fr-input"
-              type="text"
-              autoComplete="off"
-              data-1p-ignore
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={handleKeyDown}
-              value={query}
-              name="q"
-              placeholder="un identifiant RNB : 1GA7PBYM1QDY ou une adresse : 42, rue des architectes, Nantes"
-              onBlur={() => setTimeout(() => setAutocompleteActive(false), 100)}
-              onFocus={() => setAutocompleteActive(true)}
+            <AddressInput
+              onSuggestionSelected={handleSuggestionSelected}
+              overrideSuggestionsClassname={styles.autocomplete_suggestions}
+              render={(inputProps: any) => (
+                <>
+                  <input
+                    className="fr-input"
+                    data-1p-ignore
+                    name="q"
+                    placeholder="Un identifiant RNB : 1GA7PBYM1QDY ou une adresse : 42, rue des architectes, Nantes"
+                    {...inputProps}
+                  />
+                  <button className="fr-btn" type="submit">
+                    Rechercher
+                  </button>
+                </>
+              )}
             />
-            <button className="fr-btn" type="submit">
-              Rechercher
-            </button>
           </div>
-          <AddressAutocomplete
-            autocompleteActive={autocompleteActive}
-            query={query}
-            keyDown={keyDown}
-            onSuggestionSelected={handleSuggestionSelected}
-            override_class={styles.autocomplete_suggestions}
-          ></AddressAutocomplete>
         </div>
       </form>
     </Providers>

--- a/components/address/AddressSearchMap.tsx
+++ b/components/address/AddressSearchMap.tsx
@@ -12,7 +12,9 @@ import Bus from '@/utils/Bus';
 // Store
 import { useDispatch, useSelector } from 'react-redux';
 
-import AddressAutocomplete from './AddressAutocomplete';
+import AddressAutocomplete, {
+  AddressSuggestion,
+} from '@/components/address/AddressAutocomplete';
 import { Actions, AppDispatch, RootState } from '@/stores/store';
 
 export default function AddressSearchMap() {
@@ -34,8 +36,7 @@ export default function AddressSearchMap() {
 
   const addressInput = useRef<HTMLInputElement>(null);
 
-  // @ts-ignore
-  const handleKeyDown = async (e) => {
+  const handleKeyDown = async (e: React.KeyboardEvent) => {
     setAutocompleteActive(true);
     dispatch(Actions.map.setAddressSearchUnknownRNBId(false));
 
@@ -177,10 +178,15 @@ export default function AddressSearchMap() {
   }, [selectedItem]);
 
   // @ts-ignore
-  const handleSuggestionSelected = ({ suggestion }) => {
+  const handleSuggestionSelected = (suggestion: AddressSuggestion | null) => {
     if (suggestion !== null) {
       selectSuggestion(suggestion);
     }
+  };
+
+  const handleQueryResults = (query: string, results: AddressSuggestion[]) => {
+    dispatch(Actions.map.setAddressSearchQuery(query));
+    dispatch(Actions.map.setAddressSearchResults(results));
   };
 
   return (
@@ -210,6 +216,7 @@ export default function AddressSearchMap() {
           query={query}
           keyDown={keyDown}
           onSuggestionSelected={handleSuggestionSelected}
+          onQueryResults={handleQueryResults}
         ></AddressAutocomplete>
       </div>
     </>

--- a/components/address/AddressSearchMap.tsx
+++ b/components/address/AddressSearchMap.tsx
@@ -25,7 +25,7 @@ export default function AddressSearchMap() {
   // URL params
   const params = useSearchParams();
   const [query, setQuery] = useState('');
-  const [keyDown, setKeyDown] = useState(null);
+  const [keyDown, setKeyDown] = useState<React.KeyboardEvent | null>(null);
   const [autocompleteActive, setAutocompleteActive] = useState(true);
 
   // State

--- a/components/contribution/types.ts
+++ b/components/contribution/types.ts
@@ -1,0 +1,4 @@
+import { BuildingAddress as BuildingAddressFromAPI } from '@/stores/map/map-slice';
+
+export type NewAddress = { id: string; label: string };
+export type BuildingAddressType = BuildingAddressFromAPI | NewAddress;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sentry/nextjs": "^8.47.0",
         "@tryghost/content-api": "^1.11.21",
         "@turf/turf": "^7.1.0",
+        "@types/geojson": "^7946.0.16",
         "@types/node": "22.2.0",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
@@ -4012,9 +4013,10 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.14",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/geojson-vt": {
       "version": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sentry/nextjs": "^8.47.0",
     "@tryghost/content-api": "^1.11.21",
     "@turf/turf": "^7.1.0",
+    "@types/geojson": "^7946.0.16",
     "@types/node": "22.2.0",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",

--- a/stores/map/map-slice.tsx
+++ b/stores/map/map-slice.tsx
@@ -3,6 +3,17 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { BuildingStatus } from '@/stores/contribution/contribution-types';
 
+export type BuildingAddress = {
+  id: string; // Also BAN ID
+  source: string;
+  street_number: string;
+  street_rep: string;
+  street: string;
+  city_name: string;
+  city_zipcode: string;
+  city_insee_code: string;
+};
+
 export interface SelectedBuilding {
   _type: 'building';
   rnb_id: string;

--- a/tests/fixtures/pages/home-page.ts
+++ b/tests/fixtures/pages/home-page.ts
@@ -19,7 +19,7 @@ export class HomePage extends RNBPage {
     this.mapButton = page.locator('a', {
       hasText: 'Voir la carte des bâtiments',
     });
-    this.searchMapField = page.getByPlaceholder(/un identifiant RNB/);
+    this.searchMapField = page.getByPlaceholder(/un identifiant RNB/i);
     this.searchMapButton = page.locator('.fr-search-bar button[type="submit"]');
     this.searchMapSuggestions = page.locator(
       '[class*="addressAutocomplete_autocomplete_suggestions"]',


### PR DESCRIPTION
But : donner une abstraction plus haut-niveau pour avoir un combobox adresse prêt à l'emploi pour la suite.

Demo dans une page "Playground" de test (qui donne une idée de comment sera utilisé le composant par la suite) : https://batid-site-4dtd16kex-referentiel-national-des-batiments.vercel.app/playground

Petite choses faites ce faisant : 
- Typer plus fortement les composants addresses et notamment le retour de la BAN et éviter de petits bugs
- Renommer / fixer certains internals de `AddressAutocomplete`
- Enlever les reliquats d'imbrication entre composant "dumb" et state Redux

Je n'ai pas migré `AddresseSearchMap` encore car il intercepte encore un peu fortement `onKeyPress`, et je ne voulais pas m'engager dans un refacto encore plus important au détriment de la fonctionnalité, mais l'idée serait de le migrer complètement par la suite.