### PR TITLE
Changement de l'ID RNB sur bannière accueil

### DIFF
--- a/app/(normalLayout)/page.tsx
+++ b/app/(normalLayout)/page.tsx
@@ -38,7 +38,7 @@ import { getDatabases } from '@/utils/databases';
 export const revalidate = 10;
 
 export default async function Home() {
-  const bannerId = 'M11Z4KK9Y338';
+  const bannerId = '32J5WGD2D3QE';
   const breakingNews = await getBreakingNews();
   let availableDatabases = null;
   try {


### PR DESCRIPTION
On passe à 32J5WGD2D3QE suite à cette remarque : https://mattermost.incubateur.net/fab-geocommuns/pl/ekcqopw6ifgyb8q381f37n5k9e