### PR TITLE
Contour des bâtiments plus épais

### DIFF
--- a/components/map/useMapLayers.ts
+++ b/components/map/useMapLayers.ts
@@ -400,12 +400,12 @@ export const useMapLayers = ({
           ['boolean', ['feature-state', 'in_panel'], false],
           selectedBuildingColor,
           ['boolean', ['feature-state', 'hovered'], false],
-          '#132353',
+          '#87d443',
           ['>', ['get', 'contributions'], 0],
           CONTRIBUTIONS_COLOR,
-          '#1452e3',
+          '#14afe3',
         ],
-        'line-width': 1.5,
+        'line-width': 2.5,
       },
     });
 

--- a/components/map/useMapLayers.ts
+++ b/components/map/useMapLayers.ts
@@ -403,9 +403,9 @@ export const useMapLayers = ({
           '#87d443',
           ['>', ['get', 'contributions'], 0],
           CONTRIBUTIONS_COLOR,
-          '#14afe3',
+          '#1452e3',
         ],
-        'line-width': 2.5,
+        'line-width': 2.1,
       },
     });
 


### PR DESCRIPTION
Ca améliore un peu la lisibilité de la carte quand on est en vue aérienne

<img width="1653" alt="Capture d’écran 2025-05-13 à 15 25 14" src="https://github.com/user-attachments/assets/ab6dc8b9-c93b-446f-b462-ad1e43265cf2" />
