### PR TITLE
Permettre de supprimer un point d'un polygone

### DIFF
--- a/components/map/useMapEditBuildingShape.ts
+++ b/components/map/useMapEditBuildingShape.ts
@@ -84,10 +84,22 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
       };
       drawRef.current && map.on('draw.create', handleBuildingShapeCreate);
 
+      // delete a selected vertice of a polygon with the delete or backspace key
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (
+          (event.key === 'Delete' || event.key === 'Backspace') &&
+          drawRef.current?.getMode() == 'direct_select'
+        ) {
+          drawRef.current.trash();
+        }
+      };
+      window.addEventListener('keydown', handleKeyDown);
+
       // cleaning the hooks when the component is unmounted
       return () => {
         map.off('draw.update', handleBuildingShapeUpdate);
         map.off('draw.create', handleBuildingShapeCreate);
+        window.removeEventListener('keydown', handleKeyDown);
       };
     }
   }, [map, dispatch]);

--- a/components/map/useMapEditBuildingShape.ts
+++ b/components/map/useMapEditBuildingShape.ts
@@ -93,13 +93,14 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
           drawRef.current.trash();
         }
       };
-      window.addEventListener('keydown', handleKeyDown);
+      const mapContainer = map.getContainer();
+      mapContainer.addEventListener('keydown', handleKeyDown);
 
       // cleaning the hooks when the component is unmounted
       return () => {
         map.off('draw.update', handleBuildingShapeUpdate);
         map.off('draw.create', handleBuildingShapeCreate);
-        window.removeEventListener('keydown', handleKeyDown);
+        mapContainer.removeEventListener('keydown', handleKeyDown);
       };
     }
   }, [map, dispatch]);


### PR DESCRIPTION
Avec les touches `suppr` ou `backspace`.

C'est un des retours qu'on a eu lors du test de ce matin et en fait ça se fait facilement.