### PR TITLE
Désactiver la rotation de la carte

### DIFF
--- a/components/map/useMap.tsx
+++ b/components/map/useMap.tsx
@@ -54,6 +54,12 @@ export const useMap = (params?: UseMapParams) => {
         mapContainerRef.current!.style.opacity = '1';
       });
 
+      // disable map rotation using right click + drag
+      newMap.dragRotate.disable();
+
+      // disable map rotation using touch rotation gesture
+      newMap.touchZoomRotate.disableRotation();
+
       setMap(newMap);
     }
   }, []);


### PR DESCRIPTION
Pour le moment on peut faire une rotation de la carte avec le clic droit, ce qui ne sert à rien et je le fais parfois par erreur.
Je crois qu'on avait eu le retour d'un utilisateur également qui nous suggérait de l'enlever.