### PR TITLE
Disable Playwright parallelism

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  workers: '50%',
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['html'], ['json', { outputFile: 'test-results.json' }]],
   /* Snapshot path */


### PR DESCRIPTION
Dans mes tests en local, j'ai l'impression que c'est lorsqu'on lance les tests en parallèle qu'on a des failures.

Par ailleurs, j'ai vu que Playwright désactive le parallélisme en CI dans leur configuration par défaut https://playwright.dev/docs/test-configuration#basic-configuration

Anecdotiquement j'ai lancé les tests plusieurs fois sur cette PR et ils sont tous toujours passés

<img width="312" alt="Capture d’écran 2025-05-15 à 16 57 54" src="https://github.com/user-attachments/assets/662c15ab-b702-4295-bdb9-c38979ecf833" />

