### PR TITLE
Mini retouches : bouton Editer le RNB, retouche home et stats

### DIFF
--- a/app/(normalLayout)/page.tsx
+++ b/app/(normalLayout)/page.tsx
@@ -117,7 +117,7 @@ export default async function Home() {
         <div className="section">
           <div className="fr-grid-row fr-grid-row--gutters">
             <div className="fr-col-12 fr-col-md-7">
-              <div className="block block--blue">
+              <div className="block block--blue block--fill">
                 <h3 className="block__title">Carte des bâtiments</h3>
                 <p className="block__subtitle">
                   Cherchez une adresse ou un identifiant RNB et consultez les 43

--- a/app/(normalLayout)/stats/page.tsx
+++ b/app/(normalLayout)/stats/page.tsx
@@ -91,10 +91,7 @@ export default function Page() {
                   identifiants RNB
                 </div>
                 <div className="fr-pt-3w">
-                  <a
-                    href="https://www.data.gouv.fr/fr/datasets/?tag=rnb"
-                    className="fr-link"
-                  >
+                  <a href="/outils-services/rapprochement" className="fr-link">
                     Les parcourir
                   </a>
                 </div>

--- a/components/EditRNBButton.tsx
+++ b/components/EditRNBButton.tsx
@@ -1,7 +1,20 @@
+'use client';
+
 // Styles
 import styles from '@/styles/editRNBButton.module.scss';
 
+// Routes
+import { usePathname, useSearchParams } from 'next/navigation';
+
 export default function EditRNBButton({ modal }: any) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  let editUrl = '/edition';
+  if (pathname === '/carte') {
+    editUrl = `/edition?${searchParams.toString()}`;
+  }
+
   const explainBtnClickHandler = (e: React.MouseEvent) => {
     e.preventDefault();
     modal.open();
@@ -17,7 +30,7 @@ export default function EditRNBButton({ modal }: any) {
         >
           <i className="fr-icon fr-icon-question-line"></i>
         </a>
-        <a href="/edition" className={styles.editBtn}>
+        <a href={editUrl} className={styles.editBtn}>
           Éditer le RNB
         </a>
       </span>

--- a/components/RNBHeader.tsx
+++ b/components/RNBHeader.tsx
@@ -7,7 +7,6 @@ import { Notice } from '@codegouvfr/react-dsfr/Notice';
 import { createModal } from '@codegouvfr/react-dsfr/Modal';
 
 // Auth
-import { signOut } from 'next-auth/react';
 import { useSession } from 'next-auth/react';
 
 // Routes

--- a/components/RNBHeader.tsx
+++ b/components/RNBHeader.tsx
@@ -10,7 +10,7 @@ import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import { useSession } from 'next-auth/react';
 
 // Routes
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 // Logo
 import logo from '@/public/images/logo.png';
@@ -30,6 +30,7 @@ export default function RNBHeader({ withNavigation = true }: Props) {
   const { data: session } = useSession();
 
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [redirectUrl, setRedirectUrl] = useState(pathname);
 
   const [quickActions, setQuickActions] = useState([]);
@@ -114,7 +115,7 @@ export default function RNBHeader({ withNavigation = true }: Props) {
       let goBackToSiteQA = {
         iconId: 'fr-icon-arrow-left-line',
         linkProps: {
-          href: '/',
+          href: `/carte?${searchParams.toString()}`,
         },
         text: 'Retour au site',
       };


### PR DESCRIPTION
J'ai fait en sorte que le bouton Editer le RNB ait le même comportement qu'avait le toggle : si on est sur la carte de consultation, nous emmener au bon endroit sur la carte d'édition