### PR TITLE
Toaster : correction d'appels recursifs

### DIFF
--- a/components/contribution/toaster.tsx
+++ b/components/contribution/toaster.tsx
@@ -2,7 +2,7 @@ import Notice from '@codegouvfr/react-dsfr/Notice';
 import styles from '@/styles/contribution/editPanel.module.scss';
 import { useDispatch, useSelector } from 'react-redux';
 import { Actions, AppDispatch, RootState, store } from '@/stores/store';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export async function throwErrorMessageForHumans(response: Response) {
   const errorData = await response.json();
@@ -26,9 +26,8 @@ export async function throwErrorMessageForHumans(response: Response) {
 export function toasterSuccess(dispatch: AppDispatch, msg: string) {
   dispatch(
     Actions.map.setToasterInfos({
-      success: true,
-      successMsg: msg,
-      errorMsg: '',
+      state: 'success',
+      message: msg,
     }),
   );
 }
@@ -36,44 +35,53 @@ export function toasterSuccess(dispatch: AppDispatch, msg: string) {
 export function toasterError(dispatch: AppDispatch, msg: string) {
   dispatch(
     Actions.map.setToasterInfos({
-      success: false,
-      successMsg: '',
-      errorMsg: msg,
+      state: 'error',
+      message: msg,
     }),
   );
 }
 
 export function toasterReset(dispatch: AppDispatch) {
-  toasterSuccess(dispatch, '');
+  dispatch(
+    Actions.map.setToasterInfos({
+      state: null,
+      message: '',
+    }),
+  );
 }
 
 export default function Toaster() {
   const toasterInfos = useSelector(
     (state: RootState) => state.map.toasterInfos,
   );
-  const dispatch: AppDispatch = useDispatch();
+  const [showToaster, setShowToaster] = useState(false);
 
   useEffect(() => {
-    const timer = setTimeout(
-      () => {
-        toasterReset(dispatch);
-      },
-      toasterInfos.success ? 4000 : 10000,
-    );
-    return () => clearTimeout(timer);
+    if (toasterInfos.state) {
+      setShowToaster(true);
+      const timer = setTimeout(
+        () => {
+          setShowToaster(false);
+        },
+        toasterInfos.state === 'success' ? 6000 : 12000,
+      );
+      return () => clearTimeout(timer);
+    } else {
+      setShowToaster(false);
+    }
   }, [toasterInfos]);
 
   return (
     <>
       <div className={styles.noticeContainer}>
         <div
-          className={`${styles.notice} ${toasterInfos.successMsg || toasterInfos.errorMsg ? styles.noticeVisible : ''}`}
+          className={`${styles.notice} ${showToaster ? styles.noticeVisible : ''}`}
         >
-          {toasterInfos.success && (
-            <Notice title={toasterInfos.successMsg} severity="info" />
-          )}
-          {toasterInfos.errorMsg && (
-            <Notice title={toasterInfos.errorMsg} severity="warning" />
+          {showToaster && (
+            <Notice
+              title={toasterInfos.message}
+              severity={toasterInfos.state === 'success' ? 'info' : 'warning'}
+            />
           )}
         </div>
       </div>

--- a/stores/map/map-slice.tsx
+++ b/stores/map/map-slice.tsx
@@ -2,8 +2,6 @@
 
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { BuildingStatusType } from '@/stores/contribution/contribution-types';
-import type { GeoJSON } from 'geojson';
-import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { Actions } from '../store';
 
 export type BuildingAddress = {
@@ -62,9 +60,8 @@ export type MapLayer = MapBackgroundLayer | MapBuildingsLayer | MapExtraLayer;
 export type Operation = null | 'create' | 'update' | 'split' | 'merge';
 export type ShapeInteractionMode = null | 'drawing' | 'updating';
 export type ToasterInfos = {
-  success: boolean;
-  successMsg: string;
-  errorMsg: string;
+  state: null | 'success' | 'error';
+  message: string;
 };
 
 export type MapStore = {
@@ -104,7 +101,7 @@ const initialState: MapStore = {
   operation: null,
   shapeInteractionMode: null,
   buildingNewShape: null,
-  toasterInfos: { success: true, successMsg: '', errorMsg: '' },
+  toasterInfos: { state: null, message: '' },
 };
 
 export const mapSlice = createSlice({

--- a/styles/contribution/editPanel.module.scss
+++ b/styles/contribution/editPanel.module.scss
@@ -135,19 +135,18 @@ $panel-padding: 1.5*$spacing;
     z-index: 100;
     display: flex;
     justify-content: center;
-}
-
-.notice {
-    opacity: 0;
-    transform: translateY(100%);
-    transition: none;
-}
-
-.noticeVisible {
-    opacity: 1;
-    transform: translateY(0);
-    transition: opacity 0.4s ease, transform 0.5s ease;
-    pointer-events: auto;
+    .notice {
+        opacity: 0;
+        transform: translateY(100%);
+        transition: none;
+    }
+    
+    .noticeVisible {
+        opacity: 1;
+        transform: translateY(0);
+        transition: opacity 0.4s ease, transform 0.5s ease;
+        pointer-events: auto;
+    }
 }
 
 .editToggle {


### PR DESCRIPTION
Le state lié au toaster n'était pas bien choisi du tout. Je le sais pourtant que c'est mieux de mettre `state : 'success' | 'error'` que `success : bool` :)

Le souci était qu'a cause du setTimeout et du fait que j'affichais le toaster quand son contenu bougeait dans le store, un dispatch était lancé toutes les 4 secondes en permanence.