### PR TITLE
Fix modale d'info d'édition qui ne s'ouvre plus depuis la MàJ

### DIFF
--- a/app/(fullscreenMap)/layout.tsx
+++ b/app/(fullscreenMap)/layout.tsx
@@ -1,5 +1,6 @@
 import RNBHeader from '@/components/RNBHeader';
 import { Notice } from '@codegouvfr/react-dsfr/Notice';
+import { StartDsfrOnHydration } from '@codegouvfr/react-dsfr/next-app-router';
 
 export default function FullscreenLayout({
   children,
@@ -13,6 +14,7 @@ export default function FullscreenLayout({
         title="Le mode édition est en phase de développement et certaines fonctionnalités ne sont pas encore disponibles."
         severity="info"
       />
+      <StartDsfrOnHydration />
       {children}
     </>
   );

--- a/app/(map)/layout.tsx
+++ b/app/(map)/layout.tsx
@@ -1,4 +1,5 @@
 import RNBHeader from '@/components/RNBHeader';
+import { StartDsfrOnHydration } from '@codegouvfr/react-dsfr/next-app-router';
 
 export default function NoFooterLayout({
   children, // will be a page or nested layout
@@ -8,6 +9,7 @@ export default function NoFooterLayout({
   return (
     <>
       <RNBHeader />
+      <StartDsfrOnHydration />
       {children}
     </>
   );

--- a/app/(normalLayout)/definition/page.tsx
+++ b/app/(normalLayout)/definition/page.tsx
@@ -8,7 +8,6 @@ import { parse } from 'yaml';
 import BuildingList from '@/app/(normalLayout)/definition/BuildingList';
 import { BuildingExample } from '@/app/(normalLayout)/definition/BuildingList.type';
 import BuildingDistinctions from '@/app/(normalLayout)/definition/BuildingDistinctions';
-import { StartDsfrOnHydration } from '@codegouvfr/react-dsfr/next-app-router';
 
 async function fetchBuildingList() {
   const jsonDirectory = path.join(process.cwd(), 'data');
@@ -24,7 +23,6 @@ export default async function Page() {
   const buildingList = (await fetchBuildingList()) as BuildingExample[];
   return (
     <>
-      <StartDsfrOnHydration />
       <div className="fr-container">
         <div className="fr-grid-row">
           <div className="fr-col-12 fr-py-12v">

--- a/app/(normalLayout)/layout.tsx
+++ b/app/(normalLayout)/layout.tsx
@@ -4,6 +4,7 @@ import { Metadata } from 'next';
 // Components
 import { Footer } from '@codegouvfr/react-dsfr/Footer';
 import RNBHeader from '@/components/RNBHeader';
+import { StartDsfrOnHydration } from '@codegouvfr/react-dsfr/next-app-router';
 
 export const metadata: Metadata = {
   title: {
@@ -22,6 +23,7 @@ export default function WithFooterLayout({
   return (
     <>
       <RNBHeader />
+      <StartDsfrOnHydration />
       {children}
       <Footer
         brandTop={

--- a/app/(normalLayout)/login/page.tsx
+++ b/app/(normalLayout)/login/page.tsx
@@ -6,7 +6,6 @@ import { redirect } from 'next/navigation';
 import styles from '@/styles/login.module.scss';
 import LoginForm from '@/components/authentication/LoginForm';
 import CreateAccountForm from '@/components/authentication/CreateAccountForm';
-import { StartDsfrOnHydration } from '@codegouvfr/react-dsfr/next-app-router';
 
 export default async function LoginPage() {
   // We don't want to allow users that are already logged in to access this page
@@ -19,7 +18,6 @@ export default async function LoginPage() {
 
   return (
     <>
-      <StartDsfrOnHydration />
       <main className="fr-pt-md-14v" role="main">
         <div className="fr-container fr-container--fluid fr-mb-md-14v">
           <div className="fr-grid-row fr-grid-row--gutters">

--- a/app/(normalLayout)/playground/page.tsx
+++ b/app/(normalLayout)/playground/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import AddressInput from '@/components/address/AddressInput';
-import { StartDsfrOnHydration } from '@codegouvfr/react-dsfr/next-app-router';
 import { useState } from 'react';
 import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 
@@ -9,7 +8,6 @@ export default function PlaygroundPage() {
   const [displayInput, setDisplayInput] = useState(false);
   return (
     <div>
-      <StartDsfrOnHydration />
       {!displayInput && (
         <Tooltip kind="hover" title="Toggle the address input">
           <a href="#" onClick={() => setDisplayInput(true)}>

--- a/stores/provider.tsx
+++ b/stores/provider.tsx
@@ -3,6 +3,6 @@
 import { Provider } from 'react-redux';
 import { store } from './store';
 
-export function Providers({ children }) {
+export function Providers({ children }: { children: React.ReactNode }) {
   return <Provider store={store}>{children}</Provider>;
 }


### PR DESCRIPTION
C.f. https://www.notion.so/referentielnationaldesbatiments/D-veloppement-produit-62c0a0fcee8b413f88288d5837c8c5ab?p=20143ec9d11e80129426d70dbf34483f&pm=s

J'ai mis le `StartDsfr` finalement juste après le header dans les layouts pour éviter ce genre de soucis.

Cela semble fonctionner, même si du coup je suis moins sûr de comprendre comment on est supposé le placer.