### PR TITLE
Création d'un middleware

### DIFF
--- a/components/address/AddressSearchMap.tsx
+++ b/components/address/AddressSearchMap.tsx
@@ -17,6 +17,7 @@ import AddressAutocomplete, {
 } from '@/components/address/AddressAutocomplete';
 import { Actions, AppDispatch, RootState } from '@/stores/store';
 import { queryIsRnbId, queryIsCoordinates } from '@/components/address/utils';
+import { selectBuildingAndSetOperationUpdate } from '@/stores/map/map-slice';
 
 export default function AddressSearchMap() {
   const unknown_rnb_id = useSelector(
@@ -44,7 +45,7 @@ export default function AddressSearchMap() {
     // If the query is a RNB ID we bypass the address search
     if (e.key === 'Enter' && queryIsRnbId(query)) {
       const building = (await dispatch(
-        Actions.map.selectBuilding(query),
+        selectBuildingAndSetOperationUpdate(query),
       )) as any;
       if (building.payload) {
         dispatch(
@@ -80,7 +81,9 @@ export default function AddressSearchMap() {
     if (queryIsRnbId(q)) {
       setAutocompleteActive(false);
       setQuery(q);
-      const building = (await dispatch(Actions.map.selectBuilding(q))) as any;
+      const building = (await dispatch(
+        selectBuildingAndSetOperationUpdate(q),
+      )) as any;
       dispatch(
         Actions.map.setMoveTo({
           lat: parseFloat(building.payload.point.coordinates[1]),

--- a/components/contribution/EditionPanel.tsx
+++ b/components/contribution/EditionPanel.tsx
@@ -214,17 +214,6 @@ export default function EditionPanel() {
     }
   };
 
-  useEffect(() => {
-    if (operation === 'create') {
-      dispatch(Actions.map.reset());
-      dispatch(Actions.map.setShapeInteractionMode('drawing'));
-    } else if (operation === null) {
-      if (shapeInteractionMode !== null) {
-        dispatch(Actions.map.setShapeInteractionMode(null));
-      }
-    }
-  }, [operation]);
-
   return (
     <>
       <div className={styles.actions}>

--- a/components/map/useEditionMapEvents.ts
+++ b/components/map/useEditionMapEvents.ts
@@ -9,6 +9,7 @@ import {
   LAYER_BDGS_SHAPE_POINT,
   LAYER_ADS_CIRCLE,
 } from '@/components/map/useMapLayers';
+import { selectBuildingAndSetOperationUpdate } from '@/stores/map/map-slice';
 
 /**
  * Ajout et gestion des événements de la carte
@@ -46,7 +47,7 @@ export const useEditionMapEvents = (map?: maplibregl.Map) => {
             ) {
               // It is a building
               const rnb_id = featureCloseToCursor.properties.rnb_id;
-              dispatch(Actions.map.selectBuilding(rnb_id));
+              dispatch(selectBuildingAndSetOperationUpdate(rnb_id));
             } else if (featureCloseToCursor.layer.id === LAYER_ADS_CIRCLE) {
               // It is an ADS
               const file_number = featureCloseToCursor.properties.file_number;
@@ -54,7 +55,7 @@ export const useEditionMapEvents = (map?: maplibregl.Map) => {
             }
           } else {
             // click out unselects the currently selected item
-            dispatch(Actions.map.unselectItem());
+            dispatch(Actions.map.setOperation(null));
           }
         }
       };

--- a/components/map/useMapEditBuildingShape.ts
+++ b/components/map/useMapEditBuildingShape.ts
@@ -31,6 +31,9 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
   const shapeInteractionMode: ShapeInteractionMode = useSelector(
     (state: RootState) => state.map.shapeInteractionMode,
   );
+  const shapeInteractionCounter: number = useSelector(
+    (state: RootState) => state.map.shapeInteractionCounter,
+  );
   const drawRef = useRef<MapboxDraw | null>(null);
   const selectedBuildingRef = useRef<string | null>(null);
 
@@ -124,7 +127,7 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
         drawRef.current.changeMode('draw_polygon');
       }
     }
-  }, [shapeInteractionMode, dispatch]);
+  }, [shapeInteractionMode, shapeInteractionCounter, dispatch]);
 
   useEffect(() => {
     if (map) {
@@ -135,7 +138,6 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
         selectedBuilding.shape &&
         selectedBuilding.rnb_id !== selectedBuildingRef.current
       ) {
-        dispatch(Actions.map.setOperation('update'));
         drawRef.current.deleteAll();
         drawRef.current.add({
           id: BUILDING_DRAW_SHAPE_FEATURE_ID,
@@ -143,11 +145,6 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
           properties: {},
           geometry: selectedBuilding.shape,
         });
-        if (selectedBuilding.shape.type == 'Point') {
-          dispatch(Actions.map.setShapeInteractionMode(null));
-        } else {
-          dispatch(Actions.map.setShapeInteractionMode('updating'));
-        }
         // used to know if we are selecting a different building next time we click on the map
         selectedBuildingRef.current = selectedBuilding.rnb_id;
       }

--- a/stores/map/map-slice.tsx
+++ b/stores/map/map-slice.tsx
@@ -242,6 +242,13 @@ export const selectBuilding = createAsyncThunk(
   },
 );
 
+export const selectBuildingAndSetOperationUpdate =
+  (rnb_id: string) =>
+  async (dispatch: AppDispatch, getState: () => RootState) => {
+    await dispatch(Actions.map.selectBuilding(rnb_id));
+    dispatch(Actions.map.setOperation('update'));
+  };
+
 export function adsApiUrl(fileNumber: string) {
   return process.env.NEXT_PUBLIC_API_BASE + '/permis/' + fileNumber + '/';
 }

--- a/stores/store.tsx
+++ b/stores/store.tsx
@@ -3,12 +3,15 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { mapActions, mapReducer } from '@/stores/map/map-slice';
 import { appActions, appReducer } from '@/stores/app/app-slice';
+import { listenerMiddleware } from '@/stores/map/map-slice';
 
 export const store = configureStore({
   reducer: {
     map: mapReducer,
     app: appReducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().prepend(listenerMiddleware.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
Ne plus faire d'effets en cascade `selection de building`=> 'operation mis à update` ce qui posait des pbs de race conditions dans les useeffects des différents components.

A la place, passer séquentiellement dans les étapes de selection de building, puis (await) à operation='update'

Ce qui permet de résoudre pas mals de bugs d'intéraction avec la shape.

D'autre part la création du middleware permet de supprimer plusieurs `dispatch`qui étaient lancés depuis des `useEffect` de différents components et de rapatrier cette logique dans le store.