### PR TITLE
Autocomplete : plus de résultats

### DIFF
--- a/components/address/AddressAutocomplete.tsx
+++ b/components/address/AddressAutocomplete.tsx
@@ -155,6 +155,7 @@ export default function AddressAutocomplete({
     let query_url = new URL(apiUrl);
     query_url.searchParams.set('q', q);
     query_url.searchParams.set('autocomplete', '1');
+    query_url.searchParams.set('limit', '30');
 
     Object.keys(geocodeQueryParams).forEach((key) => {
       query_url.searchParams.set(key, geocodeQueryParams[key]);

--- a/components/address/AddressAutocomplete.tsx
+++ b/components/address/AddressAutocomplete.tsx
@@ -173,7 +173,7 @@ export default function AddressAutocomplete({
     });
   };
 
-  const suggestions = addressSuggestions.map((s, i) => (
+  const suggestions = addressSuggestions.slice(0, 10).map((s, i) => (
     <div
       onMouseEnter={() => setHighlightedSuggestionIndex(i)}
       onMouseDown={() => selectSuggestion(s)}


### PR DESCRIPTION
Solution peu couteuse pour améliorer l'autocomplete : demander plus de résultats à l'API de la BAN.
Comme un filtrage des résultats est réalise client-side en fonction de la distance, ça augmente la rapidité avec laquelle le bon résultat est suggéré.

Un exemple, la recherche du 6 allée candide à talence.

avant modif :
![Capture d’écran 2025-06-04 à 11 25 05](https://github.com/user-attachments/assets/3897766b-2425-48e5-9edc-d85d06f1cb23)

on trouve finalement le résultat quelques caractères plus loin :
![Capture d’écran 2025-06-04 à 11 25 40](https://github.com/user-attachments/assets/977d4b70-b98f-46ad-b4bd-776d074262ec)

Après modif, on trouve la bonne adresse beaucoup plus vite (on gagne 6 caractères tapés) :
![Capture d’écran 2025-06-04 à 11 29 42](https://github.com/user-attachments/assets/8dccf171-9e50-4a66-905d-2223198f1ebb)
