### PR TITLE
Bug fix

### DIFF
--- a/components/map/useMapEditBuildingShape.ts
+++ b/components/map/useMapEditBuildingShape.ts
@@ -122,6 +122,8 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
         }
       } else if (shapeInteractionMode === 'drawing') {
         drawRef.current.changeMode('draw_polygon');
+      } else if (shapeInteractionMode === null) {
+        drawRef.current.changeMode('simple_select');
       }
     }
   }, [shapeInteractionMode, dispatch]);


### PR DESCRIPTION
description du bug :

- je clique sur créer (un batiment)
- j’annule
- je clique sur la carte : je suis encore en mode “drawing”

https://www.notion.so/referentielnationaldesbatiments/dessin-du-batiment-bug-is-annulation-de-creation-20843ec9d11e80fc80fcf8fb4786d170?source=copy_link

PS : le changement est tout petit, ça se verra mieux apres avoir mergé #291 