### PR TITLE
Eviter les redirect lors des appels intermédiaires de merge

### DIFF
--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -2,7 +2,7 @@ import { bdgApiUrl } from '@/stores/map/map-slice';
 import { SelectedBuilding } from '@/stores/map/map-slice';
 
 export async function fetchBuilding(rnbId: string) {
-  const url = bdgApiUrl(rnbId + '?from=site&withPlots=1');
+  const url = bdgApiUrl(`${rnbId}/?from=site&withPlots=1`);
   const rnbResponse = await fetch(url);
   if (rnbResponse.ok) {
     const rnbData = (await rnbResponse.json()) as SelectedBuilding;


### PR DESCRIPTION
Actuellement chaque click sur un bâtiment candidat au merge fait un appel avec un `/` manquant, ce qui créé un deuxième appel à chaque fois vers la même url avec le `/`