### PR TITLE
Eviter de faire trop d'appels lors d'opérations de fusion

### DIFF
--- a/components/contribution/MergePanel.tsx
+++ b/components/contribution/MergePanel.tsx
@@ -19,7 +19,7 @@ export default function MergePanel() {
   const dispatch: AppDispatch = useDispatch();
   const candidatesIdToMerge = useSelector((state: RootState) =>
     state.edition.merge.candidates.map(
-      (candidate: MergeCandidate) => candidate.rnb_id,
+      (candidate: MergeCandidate) => candidate.rnbId,
     ),
   );
   const newBuilding = useSelector(

--- a/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
+++ b/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
@@ -18,7 +18,7 @@ export const useMapStateSyncSelectedBuildingsForMerge = (
 ) => {
   const dispatch: AppDispatch = useDispatch();
   const candidatesToMerge = useSelector((state: RootState) =>
-    state.edition.merge.candidates.map((candidate) => candidate.rnb_id),
+    state.edition.merge.candidates.map((candidate) => candidate.rnbId),
   );
   const newBuilding = useSelector(
     (state: RootState) => state.edition.merge.newBuilding,

--- a/stores/edition/edition-slice.tsx
+++ b/stores/edition/edition-slice.tsx
@@ -19,7 +19,7 @@ export type ToasterInfos = {
   state: null | 'success' | 'error';
   message: string;
 };
-export type MergeCandidate = { rnb_id: string; data: SelectedBuilding };
+export type MergeCandidate = { rnbId: string; data: SelectedBuilding };
 
 export type MergeInfos = {
   candidates: MergeCandidate[];
@@ -111,7 +111,7 @@ export const editionSlice = createSlice({
     },
     setRemoveCandidate(state, action: PayloadAction<string>) {
       const candidates: MergeCandidate[] = state.merge.candidates.filter(
-        (item: MergeCandidate) => item.rnb_id !== action.payload,
+        (item: MergeCandidate) => item.rnbId !== action.payload,
       );
       state.merge.candidates = candidates;
     },
@@ -322,24 +322,21 @@ export const addOrRemoveCandidate = createAsyncThunk<
   { state: RootState }
 >(
   'edition/addOrRemoveCandidate',
-  async (candidate_rnb_id: string, { getState }) => {
+  async (candidateRnbId: string, { getState }) => {
     let candidates = getState().edition.merge.candidates;
     const itemExist = candidates.some(
-      (item: MergeCandidate) => item.rnb_id === candidate_rnb_id,
+      (item: MergeCandidate) => item.rnbId === candidateRnbId,
     );
     if (itemExist) {
       // remove candidate
       return candidates.filter(
-        (item: MergeCandidate) => item.rnb_id !== candidate_rnb_id,
+        (item: MergeCandidate) => item.rnbId !== candidateRnbId,
       );
     } else {
       // add candidate
-      const building = await fetchBuilding(candidate_rnb_id);
+      const building = await fetchBuilding(candidateRnbId);
       if (building) {
-        candidates = [
-          ...candidates,
-          { rnb_id: candidate_rnb_id, data: building },
-        ];
+        candidates = [...candidates, { rnbId: candidateRnbId, data: building }];
       }
       return candidates;
     }


### PR DESCRIPTION
On faisait jusqu'à présent pour une fusion de N bâtiments N.(N+1)/2 appels, ce qui fait vite beaucoup !

Dans les grandes lignes :

- je choppe les infos liées au bâtiement au moment de sa sélection et je les stocke dans le store (contre dans le composant précédemment).
- je ne fais donc l'appel qu'au moment de l'ajout d'un bâtiment à la liste des candidats, alors qu'avant (avec le useEffect) on refaisait systématiquement un appel par candidat dès que la liste des candidats était modifiée.
- comme la liste des candidats repose maintenant sur de la donnée externe, je transforme le reducer en asyncThunk pour gérer la mise à jour du store avec de la donnée async.
- pour continuer à avoir la fonction loader, je bouge l'état du loader dans le store, ce qui nous permettra de le rajouter plus facilement pour les autres opérations que le merge.