### PR TITLE
Protection contre la perte d'une shape en cours d'édition

### DIFF
--- a/components/map/useMapEditBuildingShape.ts
+++ b/components/map/useMapEditBuildingShape.ts
@@ -47,7 +47,9 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
 
   // prevent the direct_select mode to switch to simple_select on click out
   // https://github.com/mapbox/mapbox-gl-draw/blob/78a5db85ec5e86159e2439316ed56128ba6eb5d9/src/modes/direct_select.js#L105
+  // @ts-ignore
   direct_select.clickNoTarget = function () {};
+  // @ts-ignore
   direct_select.clickInactive = function () {};
 
   // add the draw plugin to the map

--- a/components/map/useMapEditBuildingShape.ts
+++ b/components/map/useMapEditBuildingShape.ts
@@ -43,6 +43,12 @@ export const useMapEditBuildingShape = (map?: maplibregl.Map) => {
   const prevOperationRef = useRef<string | null>(null);
   const dispatch = useDispatch();
   const BUILDING_DRAW_SHAPE_FEATURE_ID = 'selected-building-shape';
+  const direct_select = MapboxDraw.modes.direct_select;
+
+  // prevent the direct_select mode to switch to simple_select on click out
+  // https://github.com/mapbox/mapbox-gl-draw/blob/78a5db85ec5e86159e2439316ed56128ba6eb5d9/src/modes/direct_select.js#L105
+  direct_select.clickNoTarget = function () {};
+  direct_select.clickInactive = function () {};
 
   // add the draw plugin to the map
   useEffect(() => {


### PR DESCRIPTION
Problème souvent remonté :  une shape est en cours de modification. L'utilisateur clique juste à côté du bâtiment en cours d'édition et paf le bâtiment est déselectionné, la modification en cours est perdue.

Maintenant ce comportement est bloqué dès que l'utilisateur a commencé à modifier la shape. S'il veut annuler ce qu'il a commencé à faire, il doit cliquer sur Annuler dans le panneau d'édition. Au bout du troisième click à l'extérieur de la shape en cours d'édition, je fais apparaitre un toaster pour le guider.

https://github.com/user-attachments/assets/bf23f497-aef0-4406-8a67-727ac961803c

