### PR TITLE
Meilleur affichage pour les gros scores de l'XP de l'été

### DIFF
--- a/components/summerGames/rankTable.tsx
+++ b/components/summerGames/rankTable.tsx
@@ -15,7 +15,6 @@ const formatCount = (count: number) => {
     const rounded = Math.round(count / 100) / 10;
     return rounded.toString().replace('.', ',') + 'K';
   }
-  //return count;
   return count.toLocaleString('fr-FR');
 };
 


### PR DESCRIPTION
Les scores au delà de 10000 cassent l'affichage. Cette PR corrige ça.
<img width="496" height="298" alt="Capture d’écran 2025-09-02 à 11 33 19" src="https://github.com/user-attachments/assets/a6eb09db-5a6c-43e3-bbb1-6e89e0aa2af1" />
