### PR TITLE
Fin de l'XP de l'été

### DIFF
--- a/app/(normalLayout)/classement/page.tsx
+++ b/app/(normalLayout)/classement/page.tsx
@@ -6,7 +6,7 @@ export default function Page() {
       <div className="fr-grid-row">
         <div className="fr-col-12 fr-col-md-12 fr-py-12v">
           <SummerGame
-            title="Le classement de l'été"
+            title="Le classement des éditions"
             limit={100}
             showRankingLink={false}
             withScoreDetails={true}

--- a/app/(normalLayout)/page.tsx
+++ b/app/(normalLayout)/page.tsx
@@ -155,6 +155,7 @@ export default async function Home() {
           }
           limit={5}
           showRankingLink={true}
+          withEndFlag={true}
         />
 
         <div className="section section__big">

--- a/components/summerGames/homeBlock.tsx
+++ b/components/summerGames/homeBlock.tsx
@@ -15,11 +15,13 @@ export default function SummerGame({
   limit,
   showRankingLink,
   withScoreDetails = false,
+  withEndFlag = false,
 }: {
   title: React.ReactNode | string;
   limit: number;
   showRankingLink?: boolean;
   withScoreDetails?: boolean;
+  withEndFlag?: boolean;
 }) {
   const { summerGamesData, loading } = useSummerGamesData(limit);
 
@@ -31,20 +33,24 @@ export default function SummerGame({
           <div className={styles.shell}>
             <div className={`section__titleblock ${styles.titleblock}`}>
               <h2 className="section__title">{title}</h2>
-
-              <div className={`section__subtitle ${styles.instruction}`}>
-                <p>
-                  Comment faire vivre un référentiel collaboratif ? <br />
-                  Comment améliorer le lien bâtiment adresse ?<br />
-                  Quels acteurs souhaitent alimenter le RNB ?
-                </p>
-                <p>
-                  Du 10 juillet au 10 septembre, le RNB organise une expérience
-                  et s&apos;ouvre largement à l&apos;édition collaborative.
-                  Faites monter le score de qualité du RNB, de votre ville et de
-                  votre département.
-                </p>
-              </div>
+              {withEndFlag && (
+                <div className={styles.endFlagShell}>
+                  <span className={styles.endFlag}>Terminée</span>
+                </div>
+              )}
+            </div>
+            <div className={`section__subtitle ${styles.instruction}`}>
+              <p>
+                L'expérience est terminée depuis le 10 septembre. À cette date,
+                le score global est de 131237 points. Les données récoltées vont
+                nous permettre de vous proposer les règles de participation au
+                RNB à la fin de l'année.
+              </p>
+              <p className={styles.highlight}>
+                La grande qualité de vos contributions nous permet de laisser
+                les éditions ouvertes jusqu'à ce que les règles de participation
+                soient établies.
+              </p>
             </div>
 
             {withScoreDetails && (

--- a/components/summerGames/homeBlock.tsx
+++ b/components/summerGames/homeBlock.tsx
@@ -42,7 +42,7 @@ export default function SummerGame({
             <div className={`section__subtitle ${styles.instruction}`}>
               <p>
                 L&apos;expérience collaborative a pris fin le 10 septembre 2025,
-                avec un score de 131237 points ! Grâce à vos contributions, nous
+                avec un score de 131361 points ! Grâce à vos contributions, nous
                 allons pouvoir proposer les règles de gouvernance de la donnée
                 du RNB d&apos;ici 2026. RDV le 16 octobre au prochain{' '}
                 <a href="https://cnig.gouv.fr/gt-bati-a25939.html">

--- a/components/summerGames/homeBlock.tsx
+++ b/components/summerGames/homeBlock.tsx
@@ -41,15 +41,20 @@ export default function SummerGame({
             </div>
             <div className={`section__subtitle ${styles.instruction}`}>
               <p>
-                L'expérience est terminée depuis le 10 septembre. À cette date,
-                le score global est de 131237 points. Les données récoltées vont
-                nous permettre de vous proposer les règles de participation au
-                RNB à la fin de l'année.
+                L&apos;expérience collaborative a pris fin le 10 septembre 2025,
+                avec un score de 131237 points ! Grâce à vos contributions, nous
+                allons pouvoir proposer les règles de gouvernance de la donnée
+                du RNB d&apos;ici 2026. RDV le 16 octobre au prochain{' '}
+                <a href="https://cnig.gouv.fr/gt-bati-a25939.html">
+                  GT Bâti du CNIG
+                </a>{' '}
+                pour celles et ceux qui souhaitent participer à la réflexion.
               </p>
               <p className={styles.highlight}>
-                La grande qualité de vos contributions nous permet de laisser
-                les éditions ouvertes jusqu'à ce que les règles de participation
-                soient établies.
+                Bonne nouvelle : face à l&apos;engouement pour l&apos;édition
+                collaborative et à la qualité de vos contributions, nous
+                laissons les outils d&apos;éditions ouverts à la communauté
+                durant les travaux du GT Bâti CNIG.
               </p>
             </div>
 

--- a/styles/summerGames.module.scss
+++ b/styles/summerGames.module.scss
@@ -515,14 +515,20 @@ body .mapSummerScoreInside {
 
 .endFlag {
   padding: 5px 20px;
-  position: absolute;
-  top: 20px;
-  right: 20px;
+
   text-transform: uppercase;
   color: rgba(37, 35, 11, 0.9);
   font-weight: bold;
   background-color: $accent-color-light;
   border-radius: 8px;
+  font-size: 0.8em;
+
+  @media screen and (min-width: $bp-md) {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 1em;
+  }
 }
 .endFlagShell {
   text-align: center;

--- a/styles/summerGames.module.scss
+++ b/styles/summerGames.module.scss
@@ -1,6 +1,6 @@
 @import 'vars.scss';
 
-$title-color: white;
+$title-color: #f2f4f9;
 
 $title-color-hover: #25589f;
 
@@ -17,6 +17,7 @@ $accent-color-light: #ffea00;
 }
 
 .shell {
+  position: relative;
   padding: 100px 1rem 70px;
   background-image: url('/images/summerGames/summergame2025.png');
   background-size: cover;
@@ -28,10 +29,11 @@ $accent-color-light: #ffea00;
 }
 
 .titleblock {
+  margin-bottom: 4rem;
   h2 {
     font-size: 4em;
     line-height: 1em;
-    margin-bottom: 4rem;
+
     text-shadow: 2px 2px 0px rgba(0, 0, 0, 0.3);
     color: white;
     font-family: SummerGameTitle, sans-serif;
@@ -68,23 +70,24 @@ $accent-color-light: #ffea00;
       }
     }
   }
+}
 
-  .instruction {
-    color: $title-color;
-    opacity: 0.95;
-    margin-bottom: 4.5rem;
-    max-width: 900px;
-    margin-left: auto;
-    margin-right: auto;
+.instruction {
+  color: $title-color;
+  opacity: 1;
+  margin-bottom: 4.5rem;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+  font-weight: 500;
 
-    p {
-      font-size: 1em;
-      line-height: 1.3em;
-    }
-    @media screen and (max-width: 640px) {
-      margin-bottom: 20px;
-      text-align: initial;
-    }
+  p {
+    font-size: 1em;
+    line-height: 1.3em;
+  }
+  @media screen and (max-width: 640px) {
+    margin-bottom: 20px;
+    text-align: initial;
   }
 }
 
@@ -504,4 +507,23 @@ body .mapSummerScoreInside {
   color: white;
   font-family: SummerGameTitle, sans-serif;
   font-weight: 500;
+}
+.highlight {
+  color: $accent-color-light;
+  font-weight: 900;
+}
+
+.endFlag {
+  padding: 5px 20px;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  text-transform: uppercase;
+  color: rgba(37, 35, 11, 0.9);
+  font-weight: bold;
+  background-color: $accent-color-light;
+  border-radius: 8px;
+}
+.endFlagShell {
+  text-align: center;
 }


### PR DESCRIPTION
L'XP se termine le 10 septembre. On modifier le bloc de la page d'accueil

<img width="1251" height="737" alt="Capture d’écran 2025-09-10 à 16 17 29" src="https://github.com/user-attachments/assets/6f63b33b-fab5-4670-a565-dc4fbd608c3e" />
