### PR TITLE
Changement de calque plus visible

### DIFF
--- a/components/map/LayersSwitcher.tsx
+++ b/components/map/LayersSwitcher.tsx
@@ -106,13 +106,15 @@ export default function LayersSwitcher({ disabledLayers = [] }: Props) {
   useEffect(() => {
     switch (mapLayers.background) {
       case 'vectorIgnStandard':
-        setBtnImage(backgroundPlanIGN);
+        setBtnImage(backgroundSatellite);
+
         break;
       case 'vectorOsm':
-        setBtnImage(backgroundPlanOSM);
+        setBtnImage(backgroundSatellite);
+
         break;
       default:
-        setBtnImage(backgroundSatellite);
+        setBtnImage(backgroundPlanIGN);
         break;
     }
   }, [mapLayers]);

--- a/styles/layerSwitcher.module.scss
+++ b/styles/layerSwitcher.module.scss
@@ -5,7 +5,7 @@
   position: absolute;
 
   @media (min-width: $bp-md) {
-    bottom: 10px;
+    bottom: 30px;
     right: 50px;
   }
 


### PR DESCRIPTION
On rend le bouton de changement de calque plus visible.
Le bouton est une vue aérienne quand la carte est en mode plan et inversement.

<img width="1409" height="693" alt="Capture d’écran 2025-09-11 à 16 39 36" src="https://github.com/user-attachments/assets/0a3db003-9bdb-49a2-995d-7290695aac51" />
