### PR TITLE
Fixer les tests E2E après le changement de home

### DIFF
--- a/tests/fixtures/pages/home-page.ts
+++ b/tests/fixtures/pages/home-page.ts
@@ -16,9 +16,11 @@ export class HomePage extends RNBPage {
   constructor(page: Page) {
     super(page, '/');
 
-    this.mapButton = page.locator('a', {
-      hasText: 'Voir la carte des bâtiments',
-    });
+    this.mapButton = page
+      .locator('a', {
+        hasText: 'Voir la carte des bâtiments',
+      })
+      .first();
     this.searchMapField = page.getByPlaceholder(/un identifiant RNB/i);
     this.searchMapButton = page.locator('.fr-search-bar button[type="submit"]');
     this.searchMapSuggestions = page.locator(


### PR DESCRIPTION
On a deux boutons, l'un caché suivant le breakpoint responsive sur lequel on est.

Au final ça nous importe peu.