### PR TITLE
remove tag_id from checkbox label

### DIFF
--- a/components/map/report/ReportFilters.tsx
+++ b/components/map/report/ReportFilters.tsx
@@ -190,7 +190,7 @@ export default function ReportFilters({ isOpen }: { isOpen?: boolean }) {
                       >
                         <div>
                           <div className={filterStyles.tagName}>
-                            {tag.tag_name} {tag.tag_id}
+                            {tag.tag_name}
                           </div>
                           <div className={filterStyles.tagCount}>
                             {openCount} signalement{openCount > 1 ? 's' : ''}{' '}


### PR DESCRIPTION
mini correction

les tags id sont affichés à côté du label : 
<img width="238" height="173" alt="Capture d’écran 2025-12-02 à 10 37 30" src="https://github.com/user-attachments/assets/4530636d-54c3-4d26-a51d-bf33c77409f8" />
