### PR TITLE
Fix le soft-lock de la carte après le clic sur un signalement qui overlap un bâtiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@codegouvfr/react-dsfr": "^1.21.1",
     "@geostarters/mapbox-gl-draw-rectangle-assisted-mode": "^3.0.4",
-    "@mapbox/mapbox-gl-draw": "git@github.com:leonkenneth/mapbox-gl-draw.git#57b5711aee629083e14235f858e3c03c5c879b37",
+    "@mapbox/mapbox-gl-draw": "git@github.com:leonkenneth/mapbox-gl-draw.git#5c5ea0c5f5bb945b5529b29c87113758492c5f28",
     "@mapgrab/map-interface": "^1.0.0",
     "@mapgrab/playwright": "^0.0.3",
     "@reduxjs/toolkit": "^2.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4(@babel/core@7.28.0)
       '@mapbox/mapbox-gl-draw':
-        specifier: git@github.com:leonkenneth/mapbox-gl-draw.git#57b5711aee629083e14235f858e3c03c5c879b37
-        version: https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/57b5711aee629083e14235f858e3c03c5c879b37
+        specifier: git@github.com:leonkenneth/mapbox-gl-draw.git#5c5ea0c5f5bb945b5529b29c87113758492c5f28
+        version: https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/5c5ea0c5f5bb945b5529b29c87113758492c5f28
       '@mapgrab/map-interface':
         specifier: ^1.0.0
         version: 1.0.2(mapbox-gl@3.14.0)(maplibre-gl@5.14.0)
@@ -442,8 +442,8 @@ packages:
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
     engines: {node: '>= 0.6'}
 
-  '@mapbox/mapbox-gl-draw@https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/57b5711aee629083e14235f858e3c03c5c879b37':
-    resolution: {tarball: https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/57b5711aee629083e14235f858e3c03c5c879b37}
+  '@mapbox/mapbox-gl-draw@https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/5c5ea0c5f5bb945b5529b29c87113758492c5f28':
+    resolution: {tarball: https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/5c5ea0c5f5bb945b5529b29c87113758492c5f28}
     version: 1.5.1
     engines: {node: ^18.0.0 || >=20.0.0}
 
@@ -4574,7 +4574,7 @@ snapshots:
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
-  '@mapbox/mapbox-gl-draw@https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/57b5711aee629083e14235f858e3c03c5c879b37':
+  '@mapbox/mapbox-gl-draw@https://codeload.github.com/leonkenneth/mapbox-gl-draw/tar.gz/5c5ea0c5f5bb945b5529b29c87113758492c5f28':
     dependencies:
       '@mapbox/geojson-area': 0.2.2
       '@mapbox/geojson-normalize': 0.0.1


### PR DESCRIPTION
- Avant : https://rnb.beta.gouv.fr/edition?q=DNFVSFZXG1V3
- Après : https://batid-site-git-fix-un-330268-referentiel-national-des-batiments.vercel.app/edition?q=DNFVSFZXG1V3&coords=44.80902%2C-0.56035%2C20.00

Reproduction steps:
- Se connecter
- Aller sur le lien cible ci-dessus
- Cliquer sur le signalement sans bouger
- Essayer maintenant de se déplacer sur la carte (KO dans le premier cas, OK dans le second)

Le fix est dans le plugin `mapbox-gl-draw` : https://github.com/mapbox/mapbox-gl-draw/compare/main...leonkenneth:mapbox-gl-draw:fix-unable-to-drag-after-selecting-overlapping-features?expand=1

Reste à faire côté `mapbox-gl-draw` : 
- Analyse plus poussée qui valide que c'est bien onStop qui stop les events handlers ✅ 
- Rajouter des tests
- Ouvrir une PR sur le repo target