### PR TITLE
panel calques carte responsive

### DIFF
--- a/styles/layerSwitcher.module.scss
+++ b/styles/layerSwitcher.module.scss
@@ -141,6 +141,7 @@
     padding-left: $body-x-padding;
     padding-right: $body-x-padding;
     padding-top: 10px;
+    overflow-x: hidden;
     overflow-y: auto;
 
     .section {

--- a/styles/layerSwitcher.module.scss
+++ b/styles/layerSwitcher.module.scss
@@ -74,6 +74,8 @@
 .modal {
   background: white;
   position: absolute;
+  display: flex;
+  flex-direction: column;
 
   @media (min-width: $bp-md) {
     bottom: 30px;
@@ -85,6 +87,7 @@
   bottom: 12px;
   right: 12px;
   left: 12px;
+  top: 12px;
 
   z-index: 302;
 
@@ -138,6 +141,7 @@
     padding-left: $body-x-padding;
     padding-right: $body-x-padding;
     padding-top: 10px;
+    overflow-y: auto;
 
     .section {
       margin-bottom: 10px;


### PR DESCRIPTION
Modification du rendu de la modale d'affichage des calques pour qu'il soit responsive.

Lorsque l'écran est petit, le haut de la modale est cachée par le header : 

<img width="1469" height="784" alt="image" src="https://github.com/user-attachments/assets/5ef321f9-6ed9-496a-805f-0c815c30ae94" />

Maintenant la modale est réduite et on peut scroller pour accéder aux différents calques et la fermer : 

<img width="1469" height="784" alt="image" src="https://github.com/user-attachments/assets/1b2d8069-f169-4f43-9cbb-7e88656a6acd" />


