### PR TITLE
Page stats : affichage des modifications par source

### DIFF
--- a/app/(normalLayout)/stats/page.tsx
+++ b/app/(normalLayout)/stats/page.tsx
@@ -83,10 +83,23 @@ export default function Page() {
             <a href="https://rnb-fr.gitbook.io/documentation/guides/editer-le-rnb-dans-les-regles-de-lart">
               contributeurs
             </a>{' '}
-            et sur l&apos;ensemble du territoire. Les mises à jour peuvent
-            porter sur la création de bâtiments, sur l&apos;enrichissement du
-            lien bâtiment-adresse ou sur d&apos;autres types d&apos;actions.
+            et l'import régulier de bases de données nationales. Les mises à
+            jour peuvent porter sur la création de bâtiments, sur
+            l&apos;enrichissement du lien bâtiment-adresse ou sur d&apos;autres
+            types d&apos;actions.
           </div>
+
+          <h3>Mise à jour : sources</h3>
+          <div className="fr-grid-row fr-grid-row--gutters fr-mb-6v">
+            <iframe
+              src="https://rnb-api.beta.gouv.fr/metabase/public/question/26709a95-83f0-47ad-819b-9108ca66aea0"
+              className="fr-col-12 fr-col-md-12"
+              height="600"
+            ></iframe>
+          </div>
+
+          <h3>Mise à jour : focus éditions</h3>
+
           <div className="fr-grid-row fr-grid-row--gutters">
             <iframe
               src="https://rnb-api.beta.gouv.fr/metabase/public/question/8da126c9-c3c3-41b7-9a95-93e5c35e26c2"

--- a/app/(normalLayout)/stats/page.tsx
+++ b/app/(normalLayout)/stats/page.tsx
@@ -83,8 +83,8 @@ export default function Page() {
             <a href="https://rnb-fr.gitbook.io/documentation/guides/editer-le-rnb-dans-les-regles-de-lart">
               contributeurs
             </a>{' '}
-            et l'import régulier de bases de données nationales. Les mises à
-            jour peuvent porter sur la création de bâtiments, sur
+            et l&apos;import régulier de bases de données nationales. Les mises
+            à jour peuvent porter sur la création de bâtiments, sur
             l&apos;enrichissement du lien bâtiment-adresse ou sur d&apos;autres
             types d&apos;actions.
           </div>


### PR DESCRIPTION
On affiche le nombre de modifications issues des éditions/import bd topo/import bal. Elles sont regroupées par mois.
C'est l'aboutissement du travail deu @jbouhadoun fait sur le backend

<img width="1313" height="1296" alt="Capture d’écran 2026-04-17 à 09 12 34" src="https://github.com/user-attachments/assets/b3ce4a9f-d19e-4b78-b801-ff895a6b89a8" />
