### PR TITLE
Lignes de découpe en rôse

### DIFF
--- a/components/contribution/drawStyle.tsx
+++ b/components/contribution/drawStyle.tsx
@@ -30,17 +30,39 @@ const styles = [
       'line-width': 3,
     },
   },
-  // Cut lines (solid orange, used for split operation)
+  // Lines seen when polygons are drawed
   {
-    id: 'gl-draw-cut-lines',
+    id: 'gl-draw-lines',
     type: 'line',
-    filter: ['all', ['==', '$type', 'LineString']],
+    filter: [
+      'all',
+      ['==', '$type', 'LineString'],
+      ['!=', 'mode', 'draw_line_string'],
+    ],
     layout: {
       'line-cap': 'round',
       'line-join': 'round',
     },
     paint: {
-      'line-color': orange,
+      'line-color': green,
+      'line-width': 3,
+    },
+  },
+  // Cut lines (solid pink, used for split operation)
+  {
+    id: 'gl-draw-cut-lines',
+    type: 'line',
+    filter: [
+      'all',
+      ['==', '$type', 'LineString'],
+      ['==', 'mode', 'draw_line_string'],
+    ],
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+    },
+    paint: {
+      'line-color': '#ff00e1',
       'line-width': 3,
     },
   },


### PR DESCRIPTION
Pour éviter que les traits de coupe se confondent avec les limites cadastrales, qui sont oranges.

<img width="368" height="316" alt="Capture d’écran 2026-05-05 à 16 26 40" src="https://github.com/user-attachments/assets/91ee9abd-eb5d-44ac-a401-431d0df23602" />
