### PR TITLE
Extraction de la logique du pointer de souris

### DIFF
--- a/components/contribution/BuildingShape.tsx
+++ b/components/contribution/BuildingShape.tsx
@@ -9,6 +9,7 @@ import styles from '@/styles/contribution/building.module.scss';
 import editPolygonIcon from '@/public/images/map/edition/edit_polygon.svg';
 import editPolygonDisabledIcon from '@/public/images/map/edition/edit_polygon_disabled.svg';
 import newPolygonIcon from '@/public/images/map/edition/new_polygon.svg';
+import MapPointerClaim from '@/components/map/MapPointerClaim';
 
 export default function BuildingShape({
   shapeInteractionMode,
@@ -87,11 +88,15 @@ export default function BuildingShape({
           </span>
           <div className="fr-text--xs fr-pt-1v">
             {shapeInteractionMode === 'drawing' && (
-              <span>
-                Redessinez la géométrie du bâtiment {selectedBuilding.rnb_id} en
-                cliquant sur la carte. Pour finaliser la géométrie, fermez le
-                polygone en <strong>recliquant sur le premier point.</strong>
-              </span>
+              <>
+                <MapPointerClaim cursor="crosshair" />
+                <span>
+                  Redessinez la géométrie du bâtiment {selectedBuilding.rnb_id}{' '}
+                  en cliquant sur la carte. Pour finaliser la géométrie, fermez
+                  le polygone en{' '}
+                  <strong>recliquant sur le premier point.</strong>
+                </span>
+              </>
             )}
           </div>
         </div>

--- a/components/contribution/CreationPanel.tsx
+++ b/components/contribution/CreationPanel.tsx
@@ -15,6 +15,7 @@ import {
   toasterError,
   toasterSuccess,
 } from './toaster';
+import MapPointerClaim from '../map/MapPointerClaim';
 
 export default function CreationPanel() {
   const dispatch: AppDispatch = useDispatch();
@@ -170,21 +171,25 @@ function BodyPanel({
   return (
     <>
       {step === 1 && (
-        <div className={`${styles.panelSection} ${styles.noPad}`}>
-          {mapCoordinates && mapCoordinates.zoom < 18 ? (
-            <div style={{ display: 'flex' }}>
-              <span className="fr-pr-2v">
-                <i className="fr-icon-feedback-line"></i>
-              </span>
-              Zoomez sur la carte pour pouvoir tracer le bâtiment avec précision
-            </div>
-          ) : (
-            <>
-              <div>Tracez la géométrie du bâtiment sur la carte.</div>
-              <div>Un double-clic termine le tracé.</div>
-            </>
-          )}
-        </div>
+        <>
+          <MapPointerClaim cursor="crosshair" />
+          <div className={`${styles.panelSection} ${styles.noPad}`}>
+            {mapCoordinates && mapCoordinates.zoom < 18 ? (
+              <div style={{ display: 'flex' }}>
+                <span className="fr-pr-2v">
+                  <i className="fr-icon-feedback-line"></i>
+                </span>
+                Zoomez sur la carte pour pouvoir tracer le bâtiment avec
+                précision
+              </div>
+            ) : (
+              <>
+                <div>Tracez la géométrie du bâtiment sur la carte.</div>
+                <div>Un double-clic termine le tracé.</div>
+              </>
+            )}
+          </div>
+        </>
       )}
       {step === 2 && (
         <>

--- a/components/contribution/SplitPanel.tsx
+++ b/components/contribution/SplitPanel.tsx
@@ -14,6 +14,7 @@ import BuildingAddresses from './BuildingAddresses';
 import BuildingStatus from './BuildingStatus';
 import BuildingInfo from './BuildingInfo';
 import GenericPanel from '@/components/panel/GenericPanel';
+import MapPointerClaim from '@/components/map/MapPointerClaim';
 import {
   throwErrorMessageForHumans,
   toasterError,
@@ -174,6 +175,7 @@ function SplitBuildingCutStep({
 
           {candidateShape && (
             <>
+              <MapPointerClaim cursor="crosshair" />
               <div style={{ display: 'flex' }} className="fr-mb-3v">
                 <span className="fr-pr-2v">
                   <i className="fr-icon-feedback-line" aria-hidden="true"></i>

--- a/components/map/EditMap.tsx
+++ b/components/map/EditMap.tsx
@@ -19,6 +19,7 @@ import { useMapSplitChildren } from '@/components/map/useMapSplitChildren';
 import { useMapStateSyncSelectedBuilding } from '@/components/map/useMapStateSyncSelectedBuilding';
 import { useMapStateSyncSelectedBuildingsForMerge } from '@/components/map/useMapStateSyncSelectedBuildingsForMerge';
 import { useMapStateSyncReport } from '@/components/map/report/useMapStateSyncReport';
+import { useMapPointer } from '@/components/map/useMapPointer';
 
 type Props = {
   disabledLayers?: MapLayer[];
@@ -52,5 +53,6 @@ export default function EditMap({
   useMapStateSyncSelectedBuilding(map);
   useMapStateSyncSelectedBuildingsForMerge(map);
   useMapStateSyncReport(map);
+  useMapPointer(map);
   return mapContainer;
 }

--- a/components/map/MapPointerClaim.tsx
+++ b/components/map/MapPointerClaim.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { Actions, AppDispatch } from '@/stores/store';
+import { MapPointer } from '@/stores/map/map-slice';
+
+type Props = {
+  cursor: MapPointer;
+};
+
+export default function MapPointerClaim({ cursor }: Props) {
+  const dispatch: AppDispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(Actions.map.setPointer(cursor));
+    return () => {
+      dispatch(Actions.map.setPointer(''));
+    };
+  }, [cursor, dispatch]);
+
+  return null;
+}

--- a/components/map/useEditionMapEvents.ts
+++ b/components/map/useEditionMapEvents.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 import { Actions, AppDispatch, RootState } from '@/stores/store';
 import { getNearestFeatureFromCursorWithBuffer } from '@/components/map/map.utils';
 import { MapMouseEvent } from 'maplibre-gl';
@@ -25,6 +25,7 @@ import { fetchBuilding } from '@/utils/requests';
  */
 export const useEditionMapEvents = (map?: maplibregl.Map) => {
   const dispatch: AppDispatch = useDispatch();
+  const store = useStore<RootState>();
   const previousHoveredFeatureId = useRef<string | undefined>(undefined);
   const previousHoveredFeatureSource = useRef<string | undefined>(undefined);
   const previousSplitCandidate = useRef<string | undefined>(undefined);
@@ -178,19 +179,11 @@ export const useEditionMapEvents = (map?: maplibregl.Map) => {
           0,
         );
 
-        if (
-          shapeInteractionMode === 'drawing' ||
-          // drawing step of the split operation
-          (operation === 'split' &&
-            cutStep === 'drawing' &&
-            splitCandidateId &&
-            selectedChildIndex === null)
-        ) {
-          map!.getCanvas().style.cursor = 'crosshair';
-        } else if (featureCloseToCursor) {
-          map!.getCanvas().style.cursor = 'pointer';
-        } else {
-          map!.getCanvas().style.cursor = '';
+        // Le survol ne change le curseur que si aucun composant n'a déclaré
+        // de claim via <MapPointerClaim />. Sinon, le claim métier l'emporte.
+        const claim = store.getState().map.pointer;
+        if (claim === '') {
+          map!.getCanvas().style.cursor = featureCloseToCursor ? 'pointer' : '';
         }
 
         if (

--- a/components/map/useMapPointer.ts
+++ b/components/map/useMapPointer.ts
@@ -1,0 +1,19 @@
+import { RootState } from '@/stores/store';
+import maplibregl from 'maplibre-gl';
+import { useEffect } from 'react';
+import { useSelector, UseSelector } from 'react-redux';
+
+/**
+ * Gestion du curseur de la souris sur la carte
+ * Gère lien entre le store et la map.
+ * @param map
+ */
+export const useMapPointer = (map?: maplibregl.Map) => {
+  const pointer = useSelector((state: RootState) => state.map.pointer);
+
+  useEffect(() => {
+    if (map) {
+      map.getCanvas().style.cursor = pointer;
+    }
+  }, [map, pointer]);
+};

--- a/stores/map/map-slice.tsx
+++ b/stores/map/map-slice.tsx
@@ -78,6 +78,7 @@ export function isValidExtraLayer(layer: MapExtraLayer): boolean {
   return validExtraLayers.includes(layer);
 }
 export type MapLayer = MapBackgroundLayer | MapBuildingsLayer | MapExtraLayer;
+export type MapPointer = 'crosshair' | 'pointer' | '';
 
 export type MapStore = {
   addressSearch: {
@@ -97,6 +98,7 @@ export type MapStore = {
   reloadBuildings?: number;
   selectedItem?: SelectedItem;
   layers: MapLayers;
+  pointer: MapPointer;
 };
 
 const initialState: MapStore = {
@@ -109,6 +111,7 @@ const initialState: MapStore = {
     buildings: 'point',
     extraLayers: [],
   },
+  pointer: 'pointer',
 };
 
 export const mapSlice = createSlice({
@@ -155,6 +158,9 @@ export const mapSlice = createSlice({
     },
     removeBuildings(state) {
       state.selectedItem = undefined;
+    },
+    setPointer(state, action) {
+      state.pointer = action.payload;
     },
   },
 


### PR DESCRIPTION
J'essaye ici de donner à chaque composant la responsabilité de dire comment il souhaite que le curseur s'affiche.
A noter qu'il existe un comportement par défaut, qui est le changement au survol d'une feature, qui ne s'applique que si aucune "claim" métier n'a lieu à ce moment là.

Autrement dit, par défaut, le curseur change quand je passe sur un bâtiment. SI je suis en train d'en créer un nouveau, le pointer souhaité (crosshair) est stocké dans le store et cela a la priorité sur le survol du bâtiment.