### PR TITLE
Fuite de listeners

### DIFF
--- a/components/map/useMapStateSyncSelectedBuilding.ts
+++ b/components/map/useMapStateSyncSelectedBuilding.ts
@@ -77,7 +77,7 @@ export const useMapStateSyncSelectedBuilding = (map?: maplibregl.Map) => {
           toggleHighlight(previousSelectedItem, selectedItem);
         }
       };
-      map.on('sourcedata', (e) => onSourceData(e));
+      map.on('sourcedata', onSourceData);
       toggleHighlight(previousSelectedItem, selectedItem);
 
       return () => {

--- a/components/map/useMapStateSyncSelectedBuilding.ts
+++ b/components/map/useMapStateSyncSelectedBuilding.ts
@@ -68,13 +68,16 @@ export const useMapStateSyncSelectedBuilding = (map?: maplibregl.Map) => {
       selectedItemHasChanged(previousSelectedItem, selectedItem)
     ) {
       // Si on arrive sur la page avec un bâtiment pré-sélectionné (q=rnbId), il se peut que ce useEffect soit exécuté avant le chargement de la source BUILDINGS_SOURCE.
-      // On ajoute donc cet événement pour palier à ce cas.
+      // Le listener s'auto-retire après le premier match : le feature-state est stocké
+      // par id de feature (pas par tuile), donc une fois posé il s'applique à toutes les
+      // tuiles chargées ensuite — pas besoin de re-fire sur chaque sourcedata.
       const onSourceData = (e: any) => {
         if (
           e.isSourceLoaded &&
           [SRC_BDGS_POINTS, SRC_BDGS_SHAPES].includes(e.sourceId)
         ) {
           toggleHighlight(previousSelectedItem, selectedItem);
+          map.off('sourcedata', onSourceData);
         }
       };
       map.on('sourcedata', onSourceData);

--- a/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
+++ b/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
@@ -119,8 +119,14 @@ function setMapLayer(
 }
 
 function removeFeatureStateInLayers(sources: string[], map: maplibregl.Map) {
+  // Le listener gère le cas où les sources ne sont pas encore chargées au moment de
+  // l'appel. Il s'auto-retire après le premier match pour ne pas re-fire à chaque
+  // chargement de tuile.
   const onSourceData = (e: any) => {
-    if (checkSource(e)) setMapLayer(sources, map, 'removeFeatureState');
+    if (checkSource(e)) {
+      setMapLayer(sources, map, 'removeFeatureState');
+      map.off('sourcedata', onSourceData);
+    }
   };
   map.on('sourcedata', onSourceData);
   setMapLayer(sources, map, 'removeFeatureState');
@@ -140,6 +146,7 @@ function setFeatureStateInLayers(
       setMapLayer(sources, map, 'setFeatureState', id, {
         in_panel: inPanel,
       });
+      map.off('sourcedata', onSourceData);
     }
   };
   map.on('sourcedata', onSourceData);

--- a/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
+++ b/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
@@ -33,10 +33,13 @@ export const useMapStateSyncSelectedBuildingsForMerge = (
   useEffect(() => {
     const prevSelected = prevSelectedRef.current;
     const sources = [SRC_BDGS_POINTS, SRC_BDGS_SHAPES];
+    const cleanups: Array<() => void> = [];
     if (operation == 'merge') {
       if (map && candidatesToMerge) {
         if (candidatesToMerge.length === 0 && prevSelected.length) {
-          setFeatureStateInLayers(sources, map, prevSelected[0], false);
+          cleanups.push(
+            setFeatureStateInLayers(sources, map, prevSelected[0], false),
+          );
         }
         candidatesToMerge.map((candidate) => {
           let inPanel = true;
@@ -49,14 +52,17 @@ export const useMapStateSyncSelectedBuildingsForMerge = (
             inPanel = false;
             id = filterIdToRemove[0];
           }
-          setFeatureStateInLayers(sources, map, id, inPanel);
+          cleanups.push(setFeatureStateInLayers(sources, map, id, inPanel));
         });
       }
       if (map && !selectedItem && !candidatesToMerge.length) {
-        removeFeatureStateInLayers(sources, map);
+        cleanups.push(removeFeatureStateInLayers(sources, map));
       }
       prevSelectedRef.current = candidatesToMerge;
     }
+    return () => {
+      cleanups.forEach((fn) => fn());
+    };
   }, [candidatesToMerge, operation]);
 
   useEffect(() => {
@@ -78,12 +84,14 @@ export const useMapStateSyncSelectedBuildingsForMerge = (
       };
       map.on('click', handleClickEvent);
       const prevOperation = prevOperationRef.current;
+      let removeCleanup: (() => void) | undefined;
       if (operation !== 'merge' && prevOperation === 'merge') {
-        removeFeatureStateInLayers(sources, map);
+        removeCleanup = removeFeatureStateInLayers(sources, map);
       }
       prevOperationRef.current = operation;
       return () => {
         map.off('click', handleClickEvent);
+        removeCleanup?.();
       };
     }
   }, [operation, candidatesToMerge, newBuilding]);
@@ -114,7 +122,7 @@ function removeFeatureStateInLayers(sources: string[], map: maplibregl.Map) {
   const onSourceData = (e: any) => {
     if (checkSource(e)) setMapLayer(sources, map, 'removeFeatureState');
   };
-  map.on('sourcedata', (e) => onSourceData(e));
+  map.on('sourcedata', onSourceData);
   setMapLayer(sources, map, 'removeFeatureState');
   return () => {
     map.off('sourcedata', onSourceData);
@@ -134,7 +142,7 @@ function setFeatureStateInLayers(
       });
     }
   };
-  map.on('sourcedata', (e) => onSourceData(e));
+  map.on('sourcedata', onSourceData);
   setMapLayer(sources, map, 'setFeatureState', id, {
     in_panel: inPanel,
   });

--- a/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
+++ b/components/map/useMapStateSyncSelectedBuildingsForMerge.ts
@@ -36,11 +36,6 @@ export const useMapStateSyncSelectedBuildingsForMerge = (
     const cleanups: Array<() => void> = [];
     if (operation == 'merge') {
       if (map && candidatesToMerge) {
-        if (candidatesToMerge.length === 0 && prevSelected.length) {
-          cleanups.push(
-            setFeatureStateInLayers(sources, map, prevSelected[0], false),
-          );
-        }
         candidatesToMerge.map((candidate) => {
           let inPanel = true;
           let id = candidate;


### PR DESCRIPTION
Trouvé avec l'aide de Claude : les map.on() et map.off() ne matchaient pas, ce qui fait que les listeners n'étaient jamais nettoyés et s'empilaient.
Ça peut expliquer qu'au bout d'un moment, la carte puisse freezer (edit: @pauletienney me dit que probablement pas, elle peut freezer dès le chargement de la page)

J'ai pu tester via des console.log() que les listeners s'empilaient précédemment et ne le font plus.