### PR TITLE
Affichage de l'orga dans l'historique

### DIFF
--- a/app/(fullscreenMap)/batiments/[id]/historique/page.tsx
+++ b/app/(fullscreenMap)/batiments/[id]/historique/page.tsx
@@ -24,7 +24,7 @@ export interface ApiHistoryItem {
       username: string;
       first_name: string;
       last_name: string;
-      organizations_names: string | null;
+      organization_name: string | null;
     } | null;
     origin: {
       type: string;

--- a/logic/history.tsx
+++ b/logic/history.tsx
@@ -75,7 +75,13 @@ export function getHistoryShortTitle(historyItem: ApiHistoryItem): string {
 export function displayAuthor(historyItem: ApiHistoryItem): string | null {
   if (historyItem?.event?.origin?.type === 'import') return 'Équipe RNB';
   if (historyItem?.event?.origin?.type === 'data_fix') return 'Équipe RNB';
-  if (historyItem?.event?.author?.username)
-    return historyItem.event.author.username;
+  if (historyItem?.event?.author?.username) {
+    let display = historyItem.event.author.username;
+    if (historyItem.event.author.organization_name) {
+      display += ` (${historyItem.event.author.organization_name})`;
+    }
+    return display;
+  }
+
   return null;
 }


### PR DESCRIPTION
On ajoute l'organisation de l'utilisateur, si on l'a
<img width="665" height="317" alt="Capture d’écran 2026-05-22 à 12 08 59" src="https://github.com/user-attachments/assets/1c1b88c8-64a0-441c-a005-62535f70bdb3" />
