### PR TITLE
Batiment marqué comme correct dans page historique

### DIFF
--- a/app/(fullscreenMap)/batiments/[id]/historique/page.tsx
+++ b/app/(fullscreenMap)/batiments/[id]/historique/page.tsx
@@ -61,6 +61,12 @@ export interface ApiHistoryItem {
     city_zipcode: string;
     city_insee_code: string;
   }>;
+  marked_as_correct_by: Array<{
+    id: string;
+    username: string;
+    display_name: string;
+    organization_name: string;
+  }>;
 }
 
 export async function generateMetadata({

--- a/components/history/Details.tsx
+++ b/components/history/Details.tsx
@@ -82,7 +82,9 @@ export default function Details({
                     </div>
                   ) : (
                     <span>
-                      <i>Ce bâtiment n'est pas encore marqué comme correct.</i>
+                      <i>
+                        Ce bâtiment n&apos;est pas encore marqué comme correct.
+                      </i>
                     </span>
                   )}
                 </span>

--- a/components/history/Details.tsx
+++ b/components/history/Details.tsx
@@ -55,46 +55,80 @@ export default function Details({
         </div>
 
         <div className={styles.detailBlock}>
-          {detailsInfo.status && (
+          {detailsInfo.marked_as_correct_by && (
             <div className={styles.detailBlockInfo}>
               <div className={styles.detailInfo}>
                 <div className={styles.detailLabel}>
                   <span className={styles.label}>
-                    Statut physique :
+                    Marqué c. correct par :
                     {detailsInfo.event?.details?.updated_fields?.includes(
-                      'status',
+                      'marked_as_correct_by',
                     ) && <ChangedIcon />}
                   </span>
                 </div>
                 <span>
-                  {BuildingStatusMap[
-                    detailsInfo.status as BuildingStatusType
-                  ] || detailsInfo.status}
+                  {detailsInfo?.marked_as_correct_by?.length ? (
+                    <div className={styles.detailAddressItems}>
+                      {detailsInfo.marked_as_correct_by.map((user, i) => (
+                        <div className="fr-mb-1v" key={i}>
+                          <span className={styles.mergePanelAddressText}>
+                            {user.display_name || user.username}
+                            {user.organization_name
+                              ? ' (' + user.organization_name + ')'
+                              : ''}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <span>
+                      <i>Ce bâtiment n'est pas encore marqué comme correct.</i>
+                    </span>
+                  )}
                 </span>
-              </div>
-              <div className={styles.banLink}>
-                <a href={formatLinkGoBackIgn(detailsInfo)} target="_blank">
-                  Consulter le site Remonter le Temps de l&apos;IGN
-                </a>
-                <br />
-                <a href={formatPanoramaxLink(detailsInfo)} target="_blank">
-                  Consulter le site Panoramax
-                </a>
               </div>
             </div>
           )}
+        </div>
+
+        {detailsInfo.status && (
           <div className={styles.detailBlockInfo}>
             <div className={styles.detailInfo}>
               <div className={styles.detailLabel}>
                 <span className={styles.label}>
-                  État :
+                  Statut physique :
                   {detailsInfo.event?.details?.updated_fields?.includes(
-                    'is_active',
+                    'status',
                   ) && <ChangedIcon />}
                 </span>
               </div>
-              <span>{detailsInfo.is_active ? 'Activé' : 'Désactivé'}</span>
+              <span>
+                {BuildingStatusMap[detailsInfo.status as BuildingStatusType] ||
+                  detailsInfo.status}
+              </span>
             </div>
+            <div className={styles.banLink}>
+              <a href={formatLinkGoBackIgn(detailsInfo)} target="_blank">
+                Consulter le site Remonter le Temps de l&apos;IGN
+              </a>
+              <br />
+              <a href={formatPanoramaxLink(detailsInfo)} target="_blank">
+                Consulter le site Panoramax
+              </a>
+            </div>
+          </div>
+        )}
+        <div className={styles.detailBlockInfo}>
+          <div className={styles.detailInfo}>
+            <div className={styles.detailLabel}>
+              <span className={styles.label}>
+                État :
+                {detailsInfo.event?.details?.updated_fields?.includes(
+                  'is_active',
+                ) && <ChangedIcon />}
+              </span>
+            </div>
+            <span>{detailsInfo.is_active ? 'Activé' : 'Désactivé'}</span>
           </div>
         </div>
         <div className={styles.detailBlockInfo}>

--- a/components/history/TimelineItem.tsx
+++ b/components/history/TimelineItem.tsx
@@ -99,6 +99,7 @@ function formatFields(field: string): string {
   if (field === 'shape') return 'forme';
   if (field === 'addresses') return 'adresses';
   if (field === 'ext_ids') return 'identifiants externes';
+  if (field === 'marked_as_correct_by') return 'marqué comme correct';
   return field;
 }
 function addDashToFields(fields: string[]): string {


### PR DESCRIPTION
Ajout de l'info dans la page d'historique d'un bâtiment.

<img width="1227" height="361" alt="Capture d’écran 2026-05-26 à 12 27 51" src="https://github.com/user-attachments/assets/8dca5960-4510-484e-9c96-6a2489d1a760" />
