### PR TITLE
Ajustements des textes du jeu de l'été

### DIFF
--- a/app/(normalLayout)/NewHome.tsx
+++ b/app/(normalLayout)/NewHome.tsx
@@ -41,7 +41,7 @@ export default async function Home() {
         {showSummerGame && (
           <SummerGame
             title="L'été des validations"
-            subtitle="Le nouveau jeu participatif du RNB"
+            subtitle="Le nouveau jeu collaboratif du RNB"
             limit={5}
             withRankingTable={true}
             showRankingLink={true}

--- a/app/(normalLayout)/classement/page.tsx
+++ b/app/(normalLayout)/classement/page.tsx
@@ -9,7 +9,7 @@ export default function Page() {
       <div className="fr-grid-row">
         <div className="fr-col-12 fr-col-md-12 fr-py-12v">
           <SummerGame
-            title="Classement du jeu de l'été"
+            title="Classement de l'été des validations"
             limit={100}
             showRankingLink={false}
             withRankingTable={true}

--- a/components/games/summerGames/editMapSummerScore.tsx
+++ b/components/games/summerGames/editMapSummerScore.tsx
@@ -63,9 +63,9 @@ export default function EditMapSummerScore({
     <div className={styles.mapSummerScore}>
       <a href="/classement" className={styles.mapSummerScoreInside}>
         <div className={styles.mapSummerScoreTitle}>
-          Trophées &amp;
+          L&apos;été des
           <br />
-          Validations
+          validations
         </div>
 
         {!loading && summerGameScore && (

--- a/components/games/summerGames/homeBlock.tsx
+++ b/components/games/summerGames/homeBlock.tsx
@@ -140,6 +140,12 @@ export default function SummerGame({
                 >
                   Participer
                 </Link>
+                <Link
+                  href="/blog/lete-des-validations-validons-ensemble-le-rnb"
+                  className={styles.btn}
+                >
+                  En savoir plus
+                </Link>
               </div>
             </div>
           </div>

--- a/components/games/summerGames/visuMapSummerScore.tsx
+++ b/components/games/summerGames/visuMapSummerScore.tsx
@@ -12,8 +12,8 @@ export default function VisuMapSummerScore() {
       <div className={styles.mapSummerScore}>
         <a href="/edition" className={styles.mapSummerScoreInside}>
           <div className={styles.mapSummerScoreTitle}>
-            L&apos;expérience <br />
-            collaborative
+            L&apos;été des <br />
+            validations
           </div>
 
           {!loading && summerGamesData && (


### PR DESCRIPTION
Ajustements de wording sur les composants du jeu de l'été :

- **Home** : "Le nouveau jeu participatif du RNB" → "Le nouveau jeu collaboratif du RNB"
- **Home** : ajout d'un bouton "En savoir plus" vers l'article de blog
- **/classement** : "Classement du jeu de l'été" → "Classement de l'été des validations"
- **/carte** : "L'expérience collaborative" → "L'été des validations"
- **/edition** : "Trophées & validations" → "L'été des validations"

🤖 Generated with [Claude Code](https://claude.com/claude-code)