### PR TITLE
Monte Next.js de 15.5.9 à 15.5.20 (correctifs de sécurité)

### DIFF
--- a/docs/research/nextjs-15.5.16-upgrade.md
+++ b/docs/research/nextjs-15.5.16-upgrade.md
@@ -1,0 +1,124 @@
+# Montée de version Next.js : 15.5.9 → 15.5.x (recherche, 2026-07-20)
+
+## Résumé (TL;DR)
+
+- **Version cible recommandée : `next@15.5.20`** (dernier patch 15.5.x, publié le 2026-07-01, dist-tag npm `backport`).
+- **15.5.16 est un minimum insuffisant** : le correctif du « Middleware / Proxy bypass via segment-prefetch routes » livré en 15.5.16 était **incomplet**. Le correctif complet ([CVE-2026-45109 / GHSA-26hh-7cqf-hhc6](https://github.com/advisories/GHSA-26hh-7cqf-hhc6)) n'est présent qu'à partir de **15.5.18**. Ce repo utilisant un middleware (CSP), le vrai minimum de sécurité est **15.5.18**.
+- Entre 15.5.9 et 15.5.20 : **4 releases de sécurité** (15.5.10, 15.5.13, 15.5.15, 15.5.16/15.5.18) couvrant **18 advisories** au total, dont plusieurs touchent directement ce repo : middleware bypass, XSS via CSP nonces, DoS de l'Image Optimization API (`images.remotePatterns` est configuré), DoS des React Server Components.
+- **Aucun breaking change** documenté : ce sont des backports de bug fixes (« This release is backporting bug fixes ») ; les peer dependencies sont inchangées, **React 19.2.3 reste compatible** (`react: ^18.2.0 || ^19.0.0`).
+- La version **15.5.17 n'existe pas sur npm** (jamais publiée) ; 15.5.12 est une re-release de 15.5.11 ; 15.5.20 ne contient aucun changement de code (publication du package `@next/swc-wasm-web` uniquement).
+- Attention : le repo impose **pnpm** (`preinstall: npx only-allow pnpm`) — la commande de mise à jour est donc `pnpm add`, pas `npm install`.
+
+## Versions et changements
+
+Versions 15.5.x publiées sur npm après 15.5.9 (source : `npm view next versions --json` et `npm view next time --json`, registre npm, consulté le 2026-07-20) :
+
+| Version                                                            | Date npm   | Type                | Contenu                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------ | ---------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [15.5.10](https://github.com/vercel/next.js/releases/tag/v15.5.10) | 2026-01-26 | **Sécurité**        | CVE-2025-59471, CVE-2025-59472, CVE-2026-23864 (voir section sécurité)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| [15.5.11](https://github.com/vercel/next.js/releases/tag/v15.5.11) | 2026-01-28 | Bug fixes           | Fix memory leak dans le span map de tracing ([#85529](https://github.com/vercel/next.js/pull/85529)) ; taille minimale des items du LRU cache pour éviter une croissance non bornée ([#89134](https://github.com/vercel/next.js/pull/89134)) ; LRU cache avec scoping par invocation ID pour le response cache en minimal mode ([#89129](https://github.com/vercel/next.js/pull/89129)) ; fixes Turbopack/NFT tracing ([#82340](https://github.com/vercel/next.js/pull/82340), [#82757](https://github.com/vercel/next.js/pull/82757), [#84155](https://github.com/vercel/next.js/pull/84155), [#85323](https://github.com/vercel/next.js/pull/85323), [#83810](https://github.com/vercel/next.js/pull/83810)) |
+| [15.5.12](https://github.com/vercel/next.js/releases/tag/v15.5.12) | 2026-02-04 | Re-release          | « This is a re-release of v15.5.11 applying the turbopack changes » ; fix « unlock in publish-native »                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| [15.5.13](https://github.com/vercel/next.js/releases/tag/v15.5.13) | 2026-03-16 | **Sécurité**        | Patch de `http-proxy` contre le request smuggling dans les rewrites — CVE-2026-29057                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| [15.5.14](https://github.com/vercel/next.js/releases/tag/v15.5.14) | 2026-03-19 | Bug fixes / feature | `next/image` : ajout d'un LRU disk cache et de l'option `images.maximumDiskCacheSize` ([#91660](https://github.com/vercel/next.js/pull/91660)) ; Pages Router : restauration de `Content-Length` et `ETag` sur les réponses JSON `/_next/data/` ([#90304](https://github.com/vercel/next.js/pull/90304))                                                                                                                                                                                                                                                                                                                                                                                                       |
+| [15.5.15](https://github.com/vercel/next.js/releases/tag/v15.5.15) | 2026-04-08 | **Sécurité**        | DoS des React Server Components — CVE-2026-23869 (cf. [changelog Vercel](https://vercel.com/changelog/summary-of-cve-2026-23869))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [15.5.16](https://github.com/vercel/next.js/releases/tag/v15.5.16) | 2026-05-06 | **Sécurité**        | 12 advisories (6 high, 4 moderate, 2 low), CVE-2026-44572 à CVE-2026-44582 — voir section sécurité                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 15.5.17                                                            | —          | —                   | **Jamais publiée sur npm** (absente de `npm view next versions`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| [15.5.18](https://github.com/vercel/next.js/releases/tag/v15.5.18) | 2026-05-07 | **Sécurité**        | Les 12 advisories de 15.5.16 **plus** le follow-up du fix incomplet du middleware bypass (CVE-2026-45109 / GHSA-26hh-7cqf-hhc6)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| [15.5.19](https://github.com/vercel/next.js/releases/tag/v15.5.19) | 2026-06-01 | Bug fix             | « Don't drop `FormData` entries » ([#94244](https://github.com/vercel/next.js/pull/94244)) — concerne les Server Actions avec `FormData`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| [15.5.20](https://github.com/vercel/next.js/releases/tag/v15.5.20) | 2026-07-01 | Packaging           | « Contains no changes except publishing `@next/swc-wasm-web` » (package non publié depuis 15.5.15)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+
+## Correctifs de sécurité
+
+Détails vérifiés via l'API GitHub Advisory (`api.github.com/advisories/<GHSA>`), qui fait autorité sur les plages de versions affectées.
+
+### 15.5.10 (release de sécurité du 2026-01-26)
+
+| Advisory                                                                 | CVE            | Sévérité | Description                                                                                              | Versions affectées → corrigée                                                                           |
+| ------------------------------------------------------------------------ | -------------- | -------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| [GHSA-9g9p-9gw9-jx7f](https://github.com/advisories/GHSA-9g9p-9gw9-jx7f) | CVE-2025-59471 | Medium   | DoS des applications self-hosted via la configuration `images.remotePatterns` de l'Image Optimizer       | `>= 10.0.0, < 15.5.10` → 15.5.10                                                                        |
+| [GHSA-5f7q-jpqc-wp7h](https://github.com/advisories/GHSA-5f7q-jpqc-wp7h) | CVE-2025-59472 | Medium   | Consommation mémoire non bornée via le PPR Resume Endpoint                                               | Les versions **stables** 15.5.x ne sont **pas** dans les plages affectées (16.x et canaries uniquement) |
+| [GHSA-83fc-fqcc-2hmg](https://github.com/advisories/GHSA-83fc-fqcc-2hmg) | CVE-2026-23864 | **High** | Multiples DoS dans React Server Components (`react-server-dom-webpack` < 19.2.4, vendorisé dans Next.js) | corrigé côté Next par 15.5.10                                                                           |
+
+### 15.5.13 (2026-03-16)
+
+| Advisory                                                                 | CVE            | Sévérité | Description                                                      | Versions affectées → corrigée   |
+| ------------------------------------------------------------------------ | -------------- | -------- | ---------------------------------------------------------------- | ------------------------------- |
+| [GHSA-ggv3-7p47-pfv8](https://github.com/advisories/GHSA-ggv3-7p47-pfv8) | CVE-2026-29057 | Medium   | HTTP request smuggling dans les rewrites (patch de `http-proxy`) | `>= 9.5.0, < 15.5.13` → 15.5.13 |
+
+### 15.5.15 (2026-04-08)
+
+| Advisory                                                                 | CVE            | Sévérité | Description                                                                       | Versions affectées → corrigée                                                                              |
+| ------------------------------------------------------------------------ | -------------- | -------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [GHSA-479c-33wc-g2pg](https://github.com/advisories/GHSA-479c-33wc-g2pg) | CVE-2026-23869 | **High** | DoS dans React Server Components (`react-server-dom-webpack` < 19.2.5, vendorisé) | corrigé côté Next par 15.5.15 ([changelog Vercel](https://vercel.com/changelog/summary-of-cve-2026-23869)) |
+
+### 15.5.16 (2026-05-06) et 15.5.18 (2026-05-07)
+
+Sévérité **high** :
+
+| Advisory                                                                 | CVE            | Description                                                             | Corrigée en         |
+| ------------------------------------------------------------------------ | -------------- | ----------------------------------------------------------------------- | ------------------- |
+| [GHSA-8h8q-6873-q5fj](https://github.com/advisories/GHSA-8h8q-6873-q5fj) | —              | DoS avec Server Components                                              | 15.5.16             |
+| [GHSA-267c-6grr-h53f](https://github.com/advisories/GHSA-267c-6grr-h53f) | CVE-2026-44575 | Middleware / Proxy bypass (App Router) via segment-prefetch routes      | 15.5.16 (incomplet) |
+| [GHSA-26hh-7cqf-hhc6](https://github.com/advisories/GHSA-26hh-7cqf-hhc6) | CVE-2026-45109 | **Follow-up du fix incomplet** ci-dessus                                | **15.5.18**         |
+| [GHSA-mg66-mrh9-m8jx](https://github.com/advisories/GHSA-mg66-mrh9-m8jx) | CVE-2026-44579 | DoS par connection exhaustion (Cache Components)                        | 15.5.16             |
+| [GHSA-492v-c6pp-mqqv](https://github.com/advisories/GHSA-492v-c6pp-mqqv) | CVE-2026-44574 | Middleware / Proxy bypass par injection de paramètre de route dynamique | 15.5.16             |
+| [GHSA-c4j6-fc7j-m34r](https://github.com/advisories/GHSA-c4j6-fc7j-m34r) | CVE-2026-44578 | SSRF via WebSocket upgrades                                             | 15.5.16             |
+| [GHSA-36qx-fr4f-26g5](https://github.com/advisories/GHSA-36qx-fr4f-26g5) | CVE-2026-44573 | Middleware / Proxy bypass (Pages Router + i18n)                         | 15.5.16             |
+
+Sévérité **moderate** :
+
+| Advisory                                                                 | CVE            | Description                                                       | Corrigée en |
+| ------------------------------------------------------------------------ | -------------- | ----------------------------------------------------------------- | ----------- |
+| [GHSA-ffhc-5mcf-pf4q](https://github.com/advisories/GHSA-ffhc-5mcf-pf4q) | CVE-2026-44581 | XSS dans les applications App Router utilisant des **CSP nonces** | 15.5.16     |
+| [GHSA-gx5p-jg67-6x7h](https://github.com/advisories/GHSA-gx5p-jg67-6x7h) | CVE-2026-44580 | XSS via scripts `beforeInteractive` avec entrée non fiable        | 15.5.16     |
+| [GHSA-h64f-5h5j-jqjh](https://github.com/advisories/GHSA-h64f-5h5j-jqjh) | CVE-2026-44577 | DoS de l'Image Optimization API                                   | 15.5.16     |
+| [GHSA-wfc6-r584-vfw7](https://github.com/advisories/GHSA-wfc6-r584-vfw7) | CVE-2026-44576 | Cache poisoning des réponses React Server Component               | 15.5.16     |
+
+Sévérité **low** : [GHSA-vfv6-92ff-j949](https://github.com/advisories/GHSA-vfv6-92ff-j949) (CVE-2026-44582, cache poisoning par collisions du cache-busting RSC) et [GHSA-3g8h-86w9-wvmq](https://github.com/advisories/GHSA-3g8h-86w9-wvmq) (CVE-2026-44572, cache poisoning des redirects du middleware), corrigées en 15.5.16.
+
+## Breaking changes / changements de comportement
+
+- Aucun breaking change documenté. Les release notes 15.5.11 à 15.5.20 précisent : « This release is backporting bug fixes. It does **not** include all pending features/changes on canary » (ex. [v15.5.11](https://github.com/vercel/next.js/releases/tag/v15.5.11)).
+- **Peer dependencies inchangées** entre 15.5.10 et 15.5.20 : `react`/`react-dom` `^18.2.0 || ^19.0.0` (source : `npm view next@15.5.16 peerDependencies`, idem 15.5.10 et 15.5.20). **React 19.2.3 est donc compatible, aucune mise à jour de React requise.**
+- Changements de comportement mineurs à connaître :
+  - 15.5.14 ([#91660](https://github.com/vercel/next.js/pull/91660)) : le cache disque de `next/image` devient un LRU borné, avec une nouvelle option `images.maximumDiskCacheSize` — comportement de cache image potentiellement différent en production self-hosted.
+  - 15.5.10/15.5.16 : durcissements de l'Image Optimizer et du routing (prefetch, paramètres dynamiques) liés aux fixes de sécurité ; à couvrir par un passage de smoke test sur les images et la navigation.
+
+## Impact sur ce repo
+
+Scan léger du repo (état au 2026-07-20) :
+
+- [`package.json`](../../package.json) : `next` épinglé en exact `15.5.9`, `react`/`react-dom` `19.2.3`, `next-auth ^4.24.12`, `@sentry/nextjs ^8.55.0`, `eslint-config-next 15.3.2`. Package manager **pnpm** (`packageManager: pnpm@10.23.0`, `preinstall: npx only-allow pnpm`).
+- [`middleware.ts`](../../middleware.ts) : middleware **CSP avec nonce** appliqué à quasi toutes les routes → **directement concerné** par les 3 advisories de middleware bypass (CVE-2026-44574, CVE-2026-44575, CVE-2026-45109 — d'où le minimum réel **15.5.18**) et par le XSS via CSP nonces (CVE-2026-44581).
+- [`next.config.js`](../../next.config.js) : `images.remotePatterns` configuré (S3 Scaleway) → **directement concerné** par CVE-2025-59471 (DoS via `remotePatterns`, fixé en 15.5.10) et CVE-2026-44577 (DoS Image Optimization API, fixé en 15.5.16). Beaucoup de composants utilisent `next/image`.
+- App Router avec React Server Components → concerné par les DoS RSC : CVE-2026-23864 (15.5.10), CVE-2026-23869 (15.5.15), GHSA-8h8q-6873-q5fj et le cache poisoning RSC (15.5.16).
+- **Server Actions** (`'use server'` dans `app/(normalLayout)/auth/mdp-oublie/page.tsx` et `app/(normalLayout)/mon-compte/page.tsx`) → concerné par le fix `FormData` de 15.5.19 ([#94244](https://github.com/vercel/next.js/pull/94244)).
+- Rewrites : pas de `rewrites()` dans `next.config.js`, mais le `tunnelRoute: '/monitoring'` de `@sentry/nextjs` s'appuie sur le mécanisme de rewrite → CVE-2026-29057 (15.5.13) potentiellement pertinent, par prudence.
+- Non concerné : Cache Components (non activé — CVE-2026-44579), i18n Pages Router (CVE-2026-44573), WebSocket upgrades custom (CVE-2026-44578), scripts `beforeInteractive` avec entrée non fiable (CVE-2026-44580) — ces fixes arrivent quand même avec la montée de version, sans action requise.
+
+## Procédure de montée de version
+
+Le repo impose pnpm ; la version étant épinglée en exact, mettre à jour explicitement (et aligner `eslint-config-next`, dont la 15.5.20 [existe sur npm](https://www.npmjs.com/package/eslint-config-next)) :
+
+```bash
+pnpm add next@15.5.20
+pnpm add eslint-config-next@15.5.20   # optionnel : alignement (actuellement 15.3.2)
+```
+
+Puis vérifier (scripts du [`package.json`](../../package.json)) :
+
+```bash
+pnpm lint      # next lint
+pnpm build     # next build (prebuild: only-include-used-icons)
+pnpm test      # vitest
+pnpm e2e       # playwright (nécessite l'environnement e2e)
+```
+
+Points de vigilance au smoke test : le header CSP + nonce sur les pages (middleware), l'optimisation d'images distantes (S3 Scaleway), les Server Actions (`mdp-oublie`, `mon-compte`), le tunnel Sentry `/monitoring`.
+
+## Sources
+
+- Registre npm : `npm view next versions --json`, `npm view next time --json`, `npm view next@{15.5.10,15.5.16,15.5.20} peerDependencies` (consultés le 2026-07-20). Dist-tags : `backport: 15.5.20`, `latest: 16.2.10`.
+- Release notes GitHub : [v15.5.10](https://github.com/vercel/next.js/releases/tag/v15.5.10) · [v15.5.11](https://github.com/vercel/next.js/releases/tag/v15.5.11) · [v15.5.12](https://github.com/vercel/next.js/releases/tag/v15.5.12) · [v15.5.13](https://github.com/vercel/next.js/releases/tag/v15.5.13) · [v15.5.14](https://github.com/vercel/next.js/releases/tag/v15.5.14) · [v15.5.15](https://github.com/vercel/next.js/releases/tag/v15.5.15) · [v15.5.16](https://github.com/vercel/next.js/releases/tag/v15.5.16) · [v15.5.18](https://github.com/vercel/next.js/releases/tag/v15.5.18) · [v15.5.19](https://github.com/vercel/next.js/releases/tag/v15.5.19) · [v15.5.20](https://github.com/vercel/next.js/releases/tag/v15.5.20)
+- GitHub Security Advisories (via `api.github.com/advisories/<id>`) : liens individuels dans les tableaux ci-dessus ; liste complète sur [github.com/vercel/next.js/security/advisories](https://github.com/vercel/next.js/security/advisories).
+- Changelog Vercel (officiel) : [Summary of CVE-2026-23869](https://vercel.com/changelog/summary-of-cve-2026-23869).

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "js-cookie": "^3.0.5",
     "lodash.debounce": "^4.0.8",
     "maplibre-gl": "^5.3.1",
-    "next": "15.5.9",
+    "next": "15.5.20",
     "next-auth": "^4.24.12",
     "polylabel": "^2.0.1",
     "react": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.8.2(react-redux@9.2.0(@types/react@19.1.5)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
       '@sentry/nextjs':
         specifier: ^8.55.0
-        version: 8.55.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)(webpack@5.101.0)
+        version: 8.55.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)(webpack@5.101.0)
       '@terraformer/wkt':
         specifier: ^2.2.1
         version: 2.2.1
@@ -61,7 +61,7 @@ importers:
         version: 1.3.17
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.5.0(next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)
+        version: 1.5.0(next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -93,11 +93,11 @@ importers:
         specifier: ^5.3.1
         version: 5.6.2
       next:
-        specifier: 15.5.9
-        version: 15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
+        specifier: 15.5.20
+        version: 15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
       next-auth:
         specifier: ^4.24.12
-        version: 4.24.12(next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 4.24.12(next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       polylabel:
         specifier: ^2.0.1
         version: 2.0.1
@@ -258,9 +258,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.4.5':
-    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
@@ -541,60 +538,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@15.5.9':
-    resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
+  '@next/env@15.5.20':
+    resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
 
   '@next/eslint-plugin-next@15.3.2':
     resolution: {integrity: sha512-ijVRTXBgnHT33aWnDtmlG+LJD+5vhc9AKTJPquGG5NKXjpKNjc62woIhFtrAcWdBobt8kqjCoaJ0q6sDQoX7aQ==}
 
-  '@next/swc-darwin-arm64@15.5.7':
-    resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
+  '@next/swc-darwin-arm64@15.5.20':
+    resolution: {integrity: sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.7':
-    resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
+  '@next/swc-darwin-x64@15.5.20':
+    resolution: {integrity: sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
-    resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    resolution: {integrity: sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.5.7':
-    resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
+  '@next/swc-linux-arm64-musl@15.5.20':
+    resolution: {integrity: sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.5.7':
-    resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
+  '@next/swc-linux-x64-gnu@15.5.20':
+    resolution: {integrity: sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.5.7':
-    resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
+  '@next/swc-linux-x64-musl@15.5.20':
+    resolution: {integrity: sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
-    resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    resolution: {integrity: sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.7':
-    resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+  '@next/swc-win32-x64-msvc@15.5.20':
+    resolution: {integrity: sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2230,9 +2227,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001731:
-    resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
-
   caniuse-lite@1.0.30001764:
     resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
 
@@ -3558,8 +3552,8 @@ packages:
       nodemailer:
         optional: true
 
-  next@15.5.9:
-    resolution: {integrity: sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==}
+  next@15.5.20:
+    resolution: {integrity: sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -4876,11 +4870,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.4.5':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
@@ -5008,7 +4997,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.3':
     dependencies:
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.3':
@@ -5147,7 +5136,7 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.0
     optional: true
 
@@ -5158,34 +5147,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.9': {}
+  '@next/env@15.5.20': {}
 
   '@next/eslint-plugin-next@15.3.2':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.7':
+  '@next/swc-darwin-arm64@15.5.20':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.7':
+  '@next/swc-darwin-x64@15.5.20':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
+  '@next/swc-linux-arm64-gnu@15.5.20':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.7':
+  '@next/swc-linux-arm64-musl@15.5.20':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.7':
+  '@next/swc-linux-x64-gnu@15.5.20':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.7':
+  '@next/swc-linux-x64-musl@15.5.20':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
+  '@next/swc-win32-arm64-msvc@15.5.20':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.7':
+  '@next/swc-win32-x64-msvc@15.5.20':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -5750,7 +5739,7 @@ snapshots:
 
   '@sentry/core@8.55.0': {}
 
-  '@sentry/nextjs@8.55.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)(webpack@5.101.0)':
+  '@sentry/nextjs@8.55.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)(webpack@5.101.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.36.0
@@ -5763,7 +5752,7 @@ snapshots:
       '@sentry/vercel-edge': 8.55.0
       '@sentry/webpack-plugin': 2.22.7(webpack@5.101.0)
       chalk: 3.0.0
-      next: 15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
+      next: 15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.11
@@ -7243,9 +7232,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.5.0(next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)':
+  '@vercel/analytics@1.5.0(next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react@19.2.3)':
     optionalDependencies:
-      next: 15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
+      next: 15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
       react: 19.2.3
 
   '@vis.gl/react-mapbox@8.0.4(mapbox-gl@3.14.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -7711,7 +7700,7 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001731
+      caniuse-lite: 1.0.30001764
       electron-to-chromium: 1.5.198
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
@@ -7764,8 +7753,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
-
-  caniuse-lite@1.0.30001731: {}
 
   caniuse-lite@1.0.30001764: {}
 
@@ -9264,13 +9251,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@4.24.12(next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-auth@4.24.12(next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.2
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
+      next: 15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.28.2
@@ -9279,24 +9266,24 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       uuid: 8.3.2
 
-  next@15.5.9(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0):
+  next@15.5.20(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.90.0):
     dependencies:
-      '@next/env': 15.5.9
+      '@next/env': 15.5.20
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001731
+      caniuse-lite: 1.0.30001764
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
+      '@next/swc-darwin-arm64': 15.5.20
+      '@next/swc-darwin-x64': 15.5.20
+      '@next/swc-linux-arm64-gnu': 15.5.20
+      '@next/swc-linux-arm64-musl': 15.5.20
+      '@next/swc-linux-x64-gnu': 15.5.20
+      '@next/swc-linux-x64-musl': 15.5.20
+      '@next/swc-win32-arm64-msvc': 15.5.20
+      '@next/swc-win32-x64-msvc': 15.5.20
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.56.1
       sass: 1.90.0


### PR DESCRIPTION
## Quoi

- `next` : **15.5.9 → 15.5.20** (dernier patch 15.5.x, aucun breaking change — uniquement des backports de correctifs).
- Ajout du rapport de recherche sourcé : `docs/research/nextjs-15.5.16-upgrade.md`.

## Pourquoi 15.5.20 et pas 15.5.16

L'objectif initial était « au moins 15.5.16 », mais la recherche a montré que :
- le fix du **middleware bypass** livré en 15.5.16 est incomplet — le complément ([CVE-2026-45109](https://github.com/advisories/GHSA-26hh-7cqf-hhc6)) n'arrive qu'en **15.5.18**, et notre middleware CSP couvre quasi toutes les routes ;
- **15.5.19** corrige la perte d'entrées `FormData` dans les Server Actions (on en a deux : `mdp-oublie`, `mon-compte`) ;
- 15.5.20 est identique à 15.5.19 côté code (re-publication de packaging).

Parmi les 18 advisories corrigées depuis 15.5.9, celles qui nous concernent directement : 3 middleware bypass (high), XSS via **CSP nonces** (notre middleware en génère), DoS de l'Image Optimization API (`images.remotePatterns` configuré), 2 DoS RSC (high), request smuggling http-proxy (tunnel Sentry). Détails et sources dans le rapport.

## Non inclus

- `eslint-config-next` reste en 15.3.2 : le bump vers 15.5.20 est bloqué par le garde-fou supply-chain de pnpm (`ERR_PNPM_TRUST_DOWNGRADE` sur `eslint-import-resolver-typescript@3.10.1`, une dépendance transitive). C'est très probablement un faux positif — cette version exacte est déjà dans notre lockfile aujourd'hui, publiée en avril 2025, aucune advisory — mais plutôt que de contourner le garde-fou, l'alignement attendra (par ex. la migration eslint 9 imposée par Next 16).
- React reste en 19.2.3 (peer deps inchangées).

## Vérifications

- [x] `pnpm lint` — seuls les warnings préexistants
- [x] `pnpm build` — OK, toutes les routes
- [x] `pnpm test` — 44/44
- [ ] CI (Vitest + Playwright)
- [ ] Smoke test sur la préversion Vercel : en-têtes CSP + nonce, images S3, `mdp-oublie` / `mon-compte`, tunnel Sentry `/monitoring`

🤖 Generated with [Claude Code](https://claude.com/claude-code)