### PR TITLE
Monte @tryghost/content-api de 1.12.0 à 1.12.10 (correctif de sécurité axios)

### DIFF
--- a/docs/research/axios-1.13.5-security-patch.md
+++ b/docs/research/axios-1.13.5-security-patch.md
@@ -1,0 +1,180 @@
+# Alerte Dependabot : axios ≥ 1.13.5 (dépendance transitive via @tryghost/content-api)
+
+> Recherche effectuée le 2026-07-20, uniquement à partir de sources primaires (advisories GitHub officiels d'axios via l'API GitHub `repos/axios/axios/security-advisories`, CHANGELOG.md du repo axios, registre npm, repo TryGhost/SDK, doc officielle pnpm.io). Chaque affirmation est sourcée. Les incertitudes sont signalées explicitement.
+
+## Résumé (TL;DR)
+
+- **L'alerte Dependabot vise [GHSA-43fc-jf86-j433](https://github.com/axios/axios/security/advisories/GHSA-43fc-jf86-j433) / CVE-2026-25639** : DoS via une clé `__proto__` dans `mergeConfig` (sévérité **High**, CVSS 7.5), corrigé dans **axios 1.13.5** (publié le 2026-02-08).
+- **Le projet n'est en pratique pas exploitable** : axios n'est même pas exécuté à runtime — `utils/blog.tsx:72-89` passe un `makeRequest` custom basé sur `fetch` à `GhostContentAPI`, qui court-circuite entièrement axios. Et même sans cela, la vulnérabilité exige une config axios contrôlée par un attaquant, ce qui n'est pas le cas ici (appels sortants vers le CMS Ghost, paramètres construits par le SDK). C'est de l'hygiène de dépendances, pas une urgence.
+- **⚠️ Monter à 1.13.5 exactement ne suffit pas** : axios a subi une vague massive d'advisories entre avril et juillet 2026 (~25 advisories publiés, dont plusieurs High, corrigés successivement en 1.15.0, 1.15.1, 1.15.2, 1.16.0 et 1.18.0). **Seul axios ≥ 1.18.0 est sans advisory connu à ce jour** (dernière version : **1.18.1**, publiée le 2026-06-22).
+- **La voie la plus propre est de mettre à jour @tryghost/content-api : 1.12.0 → 1.12.10** (dernière version, publiée le 2026-07-07). Depuis la 1.12.4, Ghost épingle axios à une version exacte, et **la 1.12.10 épingle `axios@1.18.1`**. Le diff 1.12.0 → 1.12.10 du paquet ne contient **aucun changement de code source** (uniquement bumps de dépendances, config de build et tests) → aucun breaking change. Le `package.json` du repo déclare `^1.11.21`, donc la 1.12.10 est déjà dans la plage.
+- **Commande recommandée** : `pnpm update @tryghost/content-api`, puis vérification avec `pnpm why axios` (doit afficher 1.18.1) et `pnpm audit`. Aucun override pnpm nécessaire.
+
+---
+
+## 1. Vulnérabilités corrigées entre axios 1.12.2 et 1.13.5
+
+Source : liste complète des advisories officiels du repo axios, obtenue via l'API GitHub (`gh api /repos/axios/axios/security-advisories`), recoupée avec les pages advisories individuelles.
+
+### 1.1 L'advisory qui motive l'alerte Dependabot
+
+|                        |                                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| **Advisory**           | [GHSA-43fc-jf86-j433](https://github.com/axios/axios/security/advisories/GHSA-43fc-jf86-j433) |
+| **CVE**                | CVE-2026-25639                                                                                |
+| **Titre**              | Denial of Service via `__proto__` Key in mergeConfig                                          |
+| **Sévérité**           | High — CVSS 7.5                                                                               |
+| **Versions affectées** | `>= 1.0.0` (branche 1.x) ; `<= 0.30.2` (branche 0.x)                                          |
+| **Versions corrigées** | **`>= 1.13.5`** ; `>= 0.30.3`                                                                 |
+| **Publié le**          | 2026-02-08                                                                                    |
+
+**Vecteur** : `mergeConfig` (`lib/core/mergeConfig.js`) itérait sur les clés d'objets de config sans filtrer `__proto__`. Si une application passe à axios un objet de config issu de JSON contrôlé par un attaquant (p. ex. `JSON.parse('{"__proto__": {...}}')`), la fusion provoque un `TypeError` immédiat et fait crasher le process Node → déni de service. Le correctif (PR [#7369](https://github.com/axios/axios/pull/7369)) fait ignorer les clés `__proto__`, `constructor` et `prototype` ([notes de release v1.13.5](https://github.com/axios/axios/releases/tag/v1.13.5)).
+
+### 1.2 Autre advisory dont la version corrigée est dans l'intervalle 1.12.2 → 1.13.5
+
+| Advisory                                                                                                                                | CVE            | Sévérité | Affecté                    | Corrigé     | Remarque                                                                                                                                                                                                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------- | -------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [GHSA-qj83-cq47-w5f8](https://github.com/axios/axios/security/advisories/GHSA-qj83-cq47-w5f8) — HTTP/2 Session Cleanup State Corruption | CVE-2026-39865 | Medium   | `> 1.0.0` (plage déclarée) | `>= 1.13.2` | Le code HTTP/2 n'a été introduit qu'en **1.13.0** ([changelog 1.13.0](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md), PR #7150) : la plage déclarée est plus large que le code réellement vulnérable ; **axios 1.12.2 n'embarque pas ce code**. |
+
+Pour mémoire, le DoS via `data:` URI ([GHSA-4hjh-wcwx-xvwj](https://github.com/advisories/GHSA-4hjh-wcwx-xvwj), CVE-2025-58754, High 7.5) a été corrigé en **1.12.0** : la 1.12.2 installée dans le repo est **déjà** couverte pour celui-là.
+
+### 1.3 ⚠️ Advisories qui restent ouverts sur axios 1.13.5
+
+Point important que Dependabot ne montre pas : **1.13.5 n'est pas une version "propre"**. La liste officielle des advisories du repo axios (source : [API GitHub security-advisories](https://github.com/axios/axios/security/advisories), consultée le 2026-07-20) montre une vague de publications entre avril et juillet 2026. Advisories dont la plage affectée **inclut 1.13.5** :
+
+| Vague              | Corrigé dans        | Exemples (sévérité)                                                                                                                                                                                                                       |
+| ------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-09         | **1.15.0**          | CVE-2025-62718 SSRF via bypass `NO_PROXY` (Medium) ; CVE-2026-40175 exfiltration métadonnées cloud (Medium)                                                                                                                               |
+| 2026-04-24         | **1.15.1**          | CVE-2026-42033 gadgets prototype pollution (High) ; CVE-2026-42035 header injection (High) ; CVE-2026-42043 bypass du patch `NO_PROXY` (High) ; + ~7 Medium (CRLF injection, bypass `maxContentLength`, SSRF via alias IP…)               |
+| 2026-04-24 / 05-29 | **1.15.2 / 1.16.0** | CVE-2026-42264 credential injection (High) ; CVE-2026-44492 `NO_PROXY` IPv4-mapped IPv6 (High) ; CVE-2026-44496 ReDoS cookies (High) ; CVE-2026-44486 fuite `Proxy-Authorization` (High) ; CVE-2026-44488 DoS (High) ; + plusieurs Medium |
+| 2026-07-06         | **1.18.0**          | 10 advisories sans CVE assigné, quasi tous Medium (récursion `formDataToJSON`, gadgets prototype pollution, bypass `maxBodyLength`…), dont plusieurs avec plage `>= 1.0.0`                                                                |
+
+Conclusion : **la seule cible raisonnable aujourd'hui est axios ≥ 1.18.0** (latest npm : **1.18.1**, publié le 2026-06-22 d'après le champ `time` du [registre npm](https://registry.npmjs.org/axios)). Aucun advisory publié à ce jour n'affecte 1.18.1.
+
+---
+
+## 2. Le projet est-il réellement exposé ?
+
+**Non, pour trois raisons cumulatives.**
+
+1. **axios n'est jamais exécuté.** Le repo construit son client Ghost avec un `makeRequest` custom qui utilise `fetch` natif (`/Users/paul/projects/rnb-site/utils/blog.tsx`, lignes 72-89, commentaire explicite : « The Ghost client tries to use Axios to fetch pages, which throws an error in a Next.js 14 app »). Le SDK Ghost n'appelle axios que si aucun `makeRequest` n'est fourni ; ici axios est installé dans `node_modules` mais **mort à runtime**.
+2. **Le vecteur de CVE-2026-25639 n'existe pas ici.** Il faut qu'un attaquant contrôle l'objet de config passé à axios (JSON parsé côté serveur et injecté en config de requête). Dans l'usage `@tryghost/content-api`, la config est construite par le SDK à partir de l'URL/clé du CMS (variables d'env `NEXT_GHOST_API_URL`/`NEXT_GHOST_API_KEY`) et de paramètres de pagination internes — aucune entrée utilisateur.
+3. **Les familles SSRF `NO_PROXY` et proxy ne s'appliquent pas non plus** : elles supposent qu'axios fasse des requêtes vers des URLs influencées par un attaquant derrière une config proxy — ici les appels sortants vont vers une URL fixe (le CMS Ghost).
+
+L'alerte Dependabot est donc à traiter comme de **l'hygiène de chaîne d'approvisionnement** (et pour faire disparaître l'alerte), pas comme un correctif urgent d'une faille exploitable.
+
+---
+
+## 3. Breaking changes axios 1.12.2 → 1.13.5 (et au-delà)
+
+Source : [CHANGELOG.md du repo axios (branche v1.x)](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md) et [releases GitHub](https://github.com/axios/axios/releases), sections 1.13.0 → 1.13.5 lues intégralement.
+
+**Aucune section "BREAKING CHANGES" n'apparaît dans le changelog entre 1.12.2 et 1.13.5** (la seule du fichier concerne la 1.8.0, antérieure et donc hors sujet). Changements de comportement notables quand même :
+
+| Version (date)          | Changement                                                                                                                                                                                                                                                                         |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1.13.0** (2025-10-27) | Ajout du **support HTTP/2** (opt-in, PR #7150). Pas de breaking change déclaré.                                                                                                                                                                                                    |
+| **1.13.1** (2025-10-28) | Fix régression : stream de réponse interrompu pour les statuts HTTP non-OK.                                                                                                                                                                                                        |
+| **1.13.2** (2025-11-04) | Fix « socket hang up » sur keep-alive + timeouts ; correctif de l'advisory HTTP/2 (voir §1.2).                                                                                                                                                                                     |
+| **1.13.3** (2026-01-20) | Grosse release : `AxiosError` devient une erreur native (#5558), gestion d'erreur dans le même intercepteur (#6269), condition d'export `bun`, champ `main` aligné sur les artefacts CJS. **A introduit des régressions** (dont la perte du champ `status` sur `AxiosError`).      |
+| **1.13.4** (2026-01-27) | Corrige les régressions de la 1.13.3 (merge configs cassés, exports TypeScript).                                                                                                                                                                                                   |
+| **1.13.5** (2026-02-08) | Correctif de sécurité `mergeConfig` (§1.1) ; restaure `AxiosError.status` ; ajoute l'option `useLegacyInterceptorOrder` pour **restaurer l'ordre d'exécution des intercepteurs d'avant la v1.13** — signe qu'un changement d'ordre des intercepteurs a eu lieu dans la série 1.13. |
+
+Impact pour ce repo : **nul** — le code n'utilise pas axios directement (pas d'intercepteurs, pas d'`AxiosError` attrapé), et le SDK Ghost n'utilise que `axios.get`/instance basique. Par ailleurs, pour la montée jusqu'à 1.18.1 : c'est **Ghost lui-même qui épingle `axios@1.18.1`** dans @tryghost/content-api@1.12.10 (voir §4) et fait tourner sa suite de tests dessus, ce qui sert de validation amont. Le `package.json` d'axios 1.18.1 ne déclare pas de champ `engines` (source : [registre npm](https://registry.npmjs.org/axios/latest)) — pas de contrainte Node nouvelle.
+
+---
+
+## 4. @tryghost/content-api : la mise à jour du parent règle tout
+
+Source : [registre npm @tryghost/content-api](https://registry.npmjs.org/@tryghost/content-api) (champs `dist-tags`, `versions[].dependencies`, `time`), consulté le 2026-07-20.
+
+### 4.1 Versions publiées après 1.12.0 et plage axios déclarée
+
+| Version                | Publiée le | `dependencies.axios`     |
+| ---------------------- | ---------- | ------------------------ |
+| 1.12.0 _(installée)_   | 2025-07-22 | `^1.0.0`                 |
+| 1.12.2                 | 2025-11-19 | `^1.0.0`                 |
+| 1.12.3                 | 2026-01-12 | `^1.0.0`                 |
+| 1.12.4 / 1.12.5        | 2026-02-26 | `1.13.5` (épinglé exact) |
+| 1.12.6                 | 2026-03-18 | `1.13.6`                 |
+| 1.12.7                 | 2026-04-27 | `1.15.2`                 |
+| 1.12.8                 | 2026-05-12 | `1.16.0`                 |
+| 1.12.9                 | 2026-06-08 | `1.17.0`                 |
+| **1.12.10** (`latest`) | 2026-07-07 | **`1.18.1`**             |
+
+Constats :
+
+- La version installée (1.12.0) déclare `axios: "^1.0.0"` : **la plage accepte déjà 1.13.5 et même 1.18.1**. Un simple rafraîchissement de la résolution dans le lockfile suffirait donc _techniquement_ sans toucher à @tryghost/content-api (voir §5.2 pour les limites de cette approche).
+- Depuis la 1.12.4 (juste après CVE-2026-25639), Ghost **épingle axios à une version exacte** et suit les correctifs de sécurité release après release (Renovate dans le repo [TryGhost/SDK](https://github.com/TryGhost/SDK) : commits « Update dependency axios to v1.15.0 [SECURITY] », etc.).
+- Corollaire : après passage en 1.12.10, les futurs correctifs axios nécessiteront une nouvelle release de @tryghost/content-api (le pin exact empêche un simple refresh de lockfile) — Ghost les publie rapidement d'après l'historique ci-dessus.
+
+### 4.2 Breaking changes 1.12.0 → 1.12.10 ?
+
+**Aucun.** Le diff officiel entre les deux tags ([TryGhost/SDK compare @tryghost/content-api@1.12.0...@tryghost/content-api@1.12.10](https://github.com/TryGhost/SDK/compare/@tryghost/content-api@1.12.0...@tryghost/content-api@1.12.10)) ne touche, dans `packages/content-api/`, que : `package.json` (bumps de dépendances), `rollup.config.js` (renommage de plugins de build), `LICENSE`/`README` (cosmétique) et **des tests ajoutés** (dont des tests d'intégration). Zéro modification du code source `lib/`. Ce sont toutes des releases patch (1.12.x), conformes à semver.
+
+### 4.3 Compatibilité avec ce repo
+
+`/Users/paul/projects/rnb-site/package.json` déclare `"@tryghost/content-api": "^1.11.21"` → la 1.12.10 est dans la plage, **aucune modification de `package.json` n'est nécessaire**. Le garde-fou `minimumReleaseAge: 2880` (2 jours) de `pnpm-workspace.yaml` est satisfait : content-api 1.12.10 a 13 jours, axios 1.18.1 a 28 jours.
+
+---
+
+## 5. Méthodes pnpm pour forcer une transitive (comparées)
+
+Contexte outillage : `packageManager: pnpm@10.23.0` dans `package.json` (confirmé par `pnpm --version` → 10.23.0). axios n'apparaît qu'une seule fois dans `pnpm-lock.yaml`, uniquement via @tryghost/content-api.
+
+### 5.1 Mettre à jour le parent — **recommandé ici**
+
+```bash
+pnpm update @tryghost/content-api
+```
+
+Monte à 1.12.10 (dans la plage `^1.11.21`), qui épingle `axios@1.18.1`. Résout l'alerte Dependabot **et** tous les advisories d'avril-juillet 2026, sans override à maintenir, en suivant la version validée par Ghost.
+
+### 5.2 `pnpm update axios` (refresh de résolution)
+
+Puisque la 1.12.0 installée déclare `axios: ^1.0.0`, re-résoudre la plage donnerait axios 1.18.1 sans changer @tryghost/content-api. **Réserve** : la [doc officielle de `pnpm update`](https://pnpm.io/cli/update) ne documente pas explicitement la mise à jour d'une dépendance _transitive_ nommée (l'option `--depth` n'y est illustrée que pour la récursion dans un workspace) — le comportement de `pnpm update axios` quand axios n'est pas une dépendance directe n'est donc pas garanti par la doc. C'est une option de repli, pas la voie principale ; et elle laisse le projet sur content-api 1.12.0 alors que 1.12.10 est sans risque.
+
+### 5.3 Overrides pnpm
+
+Pour pnpm 10, les overrides se déclarent dans **`pnpm-workspace.yaml`** (« the overrides field can only be set at the root of the project », [doc pnpm — settings/overrides](https://pnpm.io/settings#overrides)) :
+
+```yaml
+# pnpm-workspace.yaml
+overrides:
+  '@tryghost/content-api>axios': '>=1.18.1' # ciblage du seul parent, syntaxe "parent>enfant" documentée
+  # ou, plus simple, globalement : "axios": ">=1.18.1"
+```
+
+La syntaxe `qar@1>zoo` (n'écraser `zoo` que sous `qar@1`) est documentée sur la même page. **Non nécessaire ici** : l'override est un marteau à réserver aux cas où le parent refuse la version voulue — or content-api 1.12.10 embarque déjà la bonne version. Un override ajouterait un réglage permanent à maintenir (et à penser à retirer).
+
+---
+
+## 6. Recommandation et vérification
+
+```bash
+# 1. Mise à jour (dans /Users/paul/projects/rnb-site)
+pnpm update @tryghost/content-api
+
+# 2. Vérifications
+pnpm why axios                      # attendu : @tryghost/content-api 1.12.10 → axios 1.18.1
+pnpm ls @tryghost/content-api       # attendu : 1.12.10
+pnpm audit                          # plus d'advisory axios
+pnpm build && pnpm test             # le blog (utils/blog.tsx) est la seule surface concernée
+```
+
+Risque de la manœuvre : quasi nul (patch releases sans changement de code source côté content-api ; axios non exécuté à runtime dans ce repo). Si l'on voulait le strict minimum pour éteindre Dependabot, `axios@1.13.5` suffirait — mais ce serait rester exposé (théoriquement) à ~25 advisories publiés depuis, pour aucun gain.
+
+---
+
+## Sources
+
+- Advisory principal : https://github.com/axios/axios/security/advisories/GHSA-43fc-jf86-j433 (CVE-2026-25639)
+- Liste complète des advisories axios : https://github.com/axios/axios/security/advisories (détail machine via `gh api /repos/axios/axios/security-advisories`, consulté le 2026-07-20)
+- Advisory SSRF NO_PROXY : https://github.com/advisories/GHSA-3p68-rc4w-qgx5 (CVE-2025-62718) ; bypass du patch : https://github.com/axios/axios/security/advisories/GHSA-pmwg-cvhr-8vh7 (CVE-2026-42043)
+- Advisory data: URI (déjà corrigé en 1.12.0) : https://github.com/advisories/GHSA-4hjh-wcwx-xvwj (CVE-2025-58754)
+- Changelog axios : https://github.com/axios/axios/blob/v1.x/CHANGELOG.md ; releases : https://github.com/axios/axios/releases (dont https://github.com/axios/axios/releases/tag/v1.13.5 et v1.13.0)
+- Registre npm axios (dates, latest 1.18.1) : https://registry.npmjs.org/axios
+- Registre npm @tryghost/content-api (versions, plages axios, dates) : https://registry.npmjs.org/@tryghost/content-api
+- Diff @tryghost/content-api 1.12.0 → 1.12.10 : https://github.com/TryGhost/SDK/compare/@tryghost/content-api@1.12.0...@tryghost/content-api@1.12.10
+- Doc pnpm overrides (pnpm-workspace.yaml, syntaxe `parent>enfant`) : https://pnpm.io/settings#overrides ; doc `pnpm update` : https://pnpm.io/cli/update
+- Fichiers du repo : `/Users/paul/projects/rnb-site/package.json` (pnpm@10.23.0, `@tryghost/content-api: ^1.11.21`), `/Users/paul/projects/rnb-site/pnpm-lock.yaml` (axios 1.12.2, unique parent), `/Users/paul/projects/rnb-site/pnpm-workspace.yaml` (`minimumReleaseAge: 2880`), `/Users/paul/projects/rnb-site/utils/blog.tsx` (makeRequest custom via fetch, lignes 72-89)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@reduxjs/toolkit": "^2.8.2",
     "@sentry/nextjs": "^8.55.0",
     "@terraformer/wkt": "^2.2.1",
-    "@tryghost/content-api": "^1.11.21",
+    "@tryghost/content-api": "^1.12.10",
     "@turf/turf": "^7.1.0",
     "@types/geojson": "^7946.0.16",
     "@types/node": "22.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       '@tryghost/content-api':
-        specifier: ^1.11.21
-        version: 1.12.0
+        specifier: ^1.12.10
+        version: 1.12.10
       '@turf/turf':
         specifier: ^7.1.0
         version: 7.2.0
@@ -152,7 +152,7 @@ importers:
         version: 1.90.0
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.2.0)(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.2.0)(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1))
 
 packages:
 
@@ -532,8 +532,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1209,8 +1209,8 @@ packages:
   '@terraformer/wkt@2.2.1':
     resolution: {integrity: sha512-XDUsW/lvbMzFi7GIuRD9+UqR4QyP+5C+TugeJLMDczKIRbaHoE9J3N8zLSdyOGmnJL9B6xTS3YMMlBnMU0Ar5A==}
 
-  '@tryghost/content-api@1.12.0':
-    resolution: {integrity: sha512-rU9yrBHlVIohOLSpC9PeH9evMeNCk4OKGvI0VEwNwuwWlsQIpBn3o79DzleEN0tbMynlObYAG0IJ/EGkIumtJA==}
+  '@tryghost/content-api@1.12.10':
+    resolution: {integrity: sha512-lESZtuKKiEUsagsfUb/oxjasLKjh3gHCmUgyfdvwgcoO58GGb8UFOakZuB0ih0dpIS1IQ+hDS2KJujdgFetPog==}
 
   '@turf/along@7.2.0':
     resolution: {integrity: sha512-Cf+d2LozABdb0TJoIcJwFKB+qisJY4nMUW9z6PAuZ9UCH7AR//hy2Z06vwYCKFZKP4a7DRPkOMBadQABCyoYuw==}
@@ -1566,8 +1566,8 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/canvas-confetti@1.9.0':
     resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
@@ -1592,6 +1592,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson-vt@3.2.5':
     resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
@@ -1983,6 +1986,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2003,8 +2011,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
@@ -2105,8 +2113,8 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2118,8 +2126,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.9.14:
-    resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   bignumber.js@9.3.1:
@@ -2185,8 +2194,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2229,6 +2238,9 @@ packages:
 
   caniuse-lite@1.0.30001764:
     resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
+
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   canvas-confetti@1.9.4:
     resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
@@ -2418,6 +2430,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2450,6 +2471,10 @@ packages:
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detective@5.2.1:
@@ -2496,8 +2521,8 @@ packages:
   electron-to-chromium@1.5.198:
     resolution: {integrity: sha512-G5COfnp3w+ydVu80yprgWSfmfQaYRh9DOxfhAxstLyetKaLyl55QrNjx8C38Pc/C+RaDmb1M0Lk8wPEMQ+bGgQ==}
 
-  electron-to-chromium@1.5.267:
-    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+  electron-to-chromium@1.5.393:
+    resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
@@ -2508,8 +2533,8 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  enhanced-resolve@5.18.4:
-    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+  enhanced-resolve@5.24.2:
+    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
 
   environment@1.1.0:
@@ -2540,6 +2565,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -2738,8 +2767,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2780,8 +2809,8 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2793,8 +2822,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded-parse@2.1.2:
@@ -2954,8 +2983,8 @@ packages:
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   highlight.js@11.11.1:
@@ -3376,8 +3405,8 @@ packages:
     resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
     engines: {node: '>=18.0.0'}
 
-  loader-runner@4.3.1:
-    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   locate-path@6.0.0:
@@ -3522,6 +3551,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.5:
     resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
     engines: {node: ^18 || >=20}
@@ -3588,8 +3622,9 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3759,6 +3794,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -3794,8 +3833,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -3856,6 +3895,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
@@ -4087,9 +4130,6 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serialize-to-js@3.1.2:
     resolution: {integrity: sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==}
@@ -4341,28 +4381,55 @@ packages:
   syntax-error@1.4.0:
     resolution: {integrity: sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.3.16:
-    resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
+      '@minify-html/node': '*'
       '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
       esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
       uglify-js: '*'
       webpack: ^5.1.0
     peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
       '@swc/core':
         optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
       esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
         optional: true
       uglify-js:
         optional: true
 
-  terser@5.44.1:
-    resolution: {integrity: sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==}
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4392,6 +4459,10 @@ packages:
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyqueue@1.2.3:
@@ -4639,8 +4710,8 @@ packages:
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
-  watchpack@2.5.0:
-    resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   webidl-conversions@3.0.1:
@@ -4648,6 +4719,10 @@ packages:
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.5.0:
@@ -4757,7 +4832,7 @@ snapshots:
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4839,7 +4914,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5140,11 +5215,11 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@next/env@15.5.20': {}
@@ -5620,7 +5695,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
@@ -5850,11 +5925,12 @@ snapshots:
 
   '@terraformer/wkt@2.2.1': {}
 
-  '@tryghost/content-api@1.12.0':
+  '@tryghost/content-api@1.12.10':
     dependencies:
-      axios: 1.12.2
+      axios: 1.18.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@turf/along@7.2.0':
     dependencies:
@@ -6981,7 +7057,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7004,14 +7080,16 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson-vt@3.2.5':
     dependencies:
@@ -7101,7 +7179,7 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -7111,7 +7189,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.5.4)
       '@typescript-eslint/types': 8.39.0
-      debug: 4.4.1
+      debug: 4.4.3
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
@@ -7130,7 +7208,7 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.5.4)
       '@typescript-eslint/utils': 8.39.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.5.4)
       typescript: 5.5.4
@@ -7145,7 +7223,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.5.4)
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -7261,13 +7339,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -7382,9 +7460,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-import-phases@1.0.4(acorn@8.15.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -7402,19 +7480,21 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  acorn@8.17.0: {}
+
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -7424,10 +7504,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7550,13 +7630,15 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@1.12.2:
+  axios@1.18.1:
     dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -7564,7 +7646,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.9.14: {}
+  baseline-browser-mapping@2.10.43: {}
 
   bignumber.js@9.3.1: {}
 
@@ -7705,13 +7787,13 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
-  browserslist@4.28.1:
+  browserslist@4.28.6:
     dependencies:
-      baseline-browser-mapping: 2.9.14
-      caniuse-lite: 1.0.30001764
-      electron-to-chromium: 1.5.267
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.393
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
   buffer-from@1.1.2: {}
 
@@ -7755,6 +7837,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001764: {}
+
+  caniuse-lite@1.0.30001806: {}
 
   canvas-confetti@1.9.4: {}
 
@@ -7971,6 +8055,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -8004,7 +8092,10 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  detect-libc@2.0.4: {}
+  detect-libc@2.0.4:
+    optional: true
+
+  detect-libc@2.1.2: {}
 
   detective@5.2.1:
     dependencies:
@@ -8048,7 +8139,7 @@ snapshots:
 
   electron-to-chromium@1.5.198: {}
 
-  electron-to-chromium@1.5.267: {}
+  electron-to-chromium@1.5.393: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -8064,10 +8155,10 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  enhanced-resolve@5.18.4:
+  enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
   environment@1.1.0: {}
 
@@ -8095,7 +8186,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -8159,16 +8250,20 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
   es-set-tostringtag@2.1.0:
     dependencies:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -8211,7 +8306,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
@@ -8246,7 +8341,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -8274,7 +8369,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 8.57.1
-      hasown: 2.0.2
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.2
@@ -8296,7 +8391,7 @@ snapshots:
       es-iterator-helpers: 1.2.1
       eslint: 8.57.1
       estraverse: 5.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
       object.entries: 1.1.9
@@ -8449,7 +8544,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.3: {}
 
   fastq@1.19.1:
     dependencies:
@@ -8462,6 +8557,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -8484,18 +8583,18 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded-parse@2.1.2: {}
@@ -8516,7 +8615,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -8544,18 +8643,18 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
 
@@ -8652,7 +8751,7 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -8675,7 +8774,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8736,7 +8835,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   is-array-buffer@3.0.5:
@@ -8779,7 +8878,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -8847,7 +8946,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-set@2.0.3: {}
 
@@ -8894,7 +8993,7 @@ snapshots:
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       has-symbols: 1.1.0
@@ -9012,7 +9111,7 @@ snapshots:
 
   lightningcss@1.32.0:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
     optionalDependencies:
       lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
@@ -9052,7 +9151,7 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
 
-  loader-runner@4.3.1: {}
+  loader-runner@4.3.2: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -9243,6 +9342,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.16: {}
+
   nanoid@5.1.5: {}
 
   napi-postinstall@0.3.2: {}
@@ -9301,7 +9402,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.51: {}
 
   normalize-path@3.0.0: {}
 
@@ -9476,6 +9577,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   pidtree@0.6.0: {}
 
   playwright-core@1.56.1: {}
@@ -9509,9 +9612,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.10:
+  postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9555,6 +9658,8 @@ snapshots:
   protocol-buffers-schema@3.6.0: {}
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   public-encrypt@4.0.3:
     dependencies:
@@ -9689,7 +9794,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       module-details-from-path: 1.0.4
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -9811,17 +9916,13 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   semver@6.3.1: {}
 
   semver@7.7.2: {}
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
 
   serialize-to-js@3.1.2: {}
 
@@ -10142,21 +10243,20 @@ snapshots:
     dependencies:
       acorn-node: 1.8.2
 
-  tapable@2.3.0: {}
+  tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.3.16(webpack@5.101.0):
+  terser-webpack-plugin@5.6.1(webpack@5.101.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.1
+      terser: 5.49.0
       webpack: 5.101.0
 
-  terser@5.44.1:
+  terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -10186,6 +10286,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyqueue@1.2.3: {}
 
@@ -10348,9 +10453,9 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -10377,24 +10482,24 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1):
+  vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
+      picomatch: 4.0.5
+      postcss: 8.5.19
       rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.2.0
       fsevents: 2.3.3
       sass: 1.90.0
-      terser: 5.44.1
+      terser: 5.49.0
       yaml: 2.8.1
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.2.0)(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.2.0)(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -10411,7 +10516,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 8.0.10(@types/node@22.2.0)(sass@1.90.0)(terser@5.49.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -10421,47 +10526,57 @@ snapshots:
 
   vm-browserify@1.1.2: {}
 
-  watchpack@2.5.0:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   webidl-conversions@3.0.1: {}
 
   webpack-sources@3.3.3: {}
 
+  webpack-sources@3.5.1: {}
+
   webpack-virtual-modules@0.5.0: {}
 
   webpack@5.101.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.6
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.4
+      enhanced-resolve: 5.24.2
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(webpack@5.101.0)
-      watchpack: 2.5.0
-      webpack-sources: 3.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(webpack@5.101.0)
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
 
   wgs84@0.0.0: {}


### PR DESCRIPTION
## Contexte

Dependabot signale une vulnérabilité DoS dans axios < 1.13.5 ([GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) / CVE-2026-25639, sévérité High 7.5). axios n'est **pas une dépendance directe** du projet : il arrive uniquement via `@tryghost/content-api`.

## Correctif

Montée de `@tryghost/content-api` 1.12.0 → 1.12.10, qui épingle **axios 1.18.1** — au-delà du minimum 1.13.5 demandé, et au niveau où tous les advisories axios connus sont corrigés (~25 advisories publiés entre avril et juillet 2026 restaient ouverts sur 1.13.5).

- Aucun changement de code source dans `@tryghost/content-api` entre 1.12.0 et 1.12.10 (uniquement des bumps de dépendances et des tests).
- Exposition réelle quasi nulle de toute façon : `utils/blog.tsx` passe un `makeRequest` custom basé sur `fetch` au client Ghost, donc axios n'est jamais exécuté à runtime.
- `pnpm audit` ne remonte plus aucun advisory axios après la mise à jour.

Analyse détaillée avec sources : `docs/research/axios-1.13.5-security-patch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)