### PR TITLE
Corrige le positionnement du sélecteur de calques (régression sass 1.101)

### DIFF
--- a/styles/layerSwitcher.module.scss
+++ b/styles/layerSwitcher.module.scss
@@ -4,13 +4,13 @@
   background: white;
   position: absolute;
 
+  bottom: 185px;
+  right: 10px;
+
   @media (min-width: $bp-md) {
     bottom: 30px;
     right: 50px;
   }
-
-  bottom: 185px;
-  right: 10px;
 
   z-index: 300;
   padding: 4px;
@@ -81,17 +81,17 @@
   display: flex;
   flex-direction: column;
 
+  bottom: 12px;
+  right: 12px;
+  left: 12px;
+  top: 12px;
+
   @media (min-width: $bp-md) {
     bottom: 30px;
     right: 50px;
     width: 312px;
     left: auto;
   }
-
-  bottom: 12px;
-  right: 12px;
-  left: 12px;
-  top: 12px;
 
   z-index: 302;
 


### PR DESCRIPTION
## Problème

Depuis la montée de sass de `^1.77.8` à `^1.101.0` (#481), sur desktop :
- le bouton « Calques » s'affichait **au-dessus** des contrôles de la carte (au lieu d'à leur gauche) ;
- la modal des calques s'étalait jusqu'au **bord gauche** de l'écran (au lieu d'être ancrée à droite).

## Cause

Dart Sass a appliqué le changement « [mixed-decls](https://sass-lang.com/d/mixed-decls) » : les déclarations placées **après** une règle imbriquée ne sont plus remontées avant elle dans le CSS compilé, l'ordre source est désormais respecté.

Dans `layerSwitcher.module.scss`, les positions mobile de `.btn` et `.modal` étaient déclarées après le bloc `@media` desktop. Avant, elles étaient remontées avant le `@media` qui gagnait donc la cascade sur desktop ; maintenant elles sortent après et écrasent les valeurs desktop partout.

## Correctif

Déclaration des styles mobile **avant** les blocs `@media` (mobile-first), pour `.btn` et `.modal`. Le CSS compilé retrouve l'ordre correct quelle que soit la version de Sass. Vérifié en local : bouton à gauche des contrôles, modal ancrée à droite.

## À noter

Cinq autres fichiers ont le même pattern (`feve`, `panel`, `summerGames`, `trophyWon`, `report/form`), mais avec des sélecteurs enfants et non des `@media` : pas d'impact visuel, non touchés ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)