### PR TITLE
Afficher immédiatement les validations sur la carte

### DIFF
--- a/components/ValidationToggler.tsx
+++ b/components/ValidationToggler.tsx
@@ -75,6 +75,7 @@ export default function ValidationToggler({
         );
         // Re-consultation du bâtiment pour rafraîchir validated_by (réponse 204).
         await dispatch(Actions.map.selectBuilding(building.rnb_id));
+        dispatch(Actions.map.reloadBuildings());
 
         // Détection des trophées gagnés grâce à cette validation (nouveau type
         // ou passage à un palier supérieur).


### PR DESCRIPTION
Quand on valide, on recharge les bâtiments pour que le bâtiment qu'on vient de valider apparaisse immédiatement avec ses petits ✅ ✅ ✅ 